### PR TITLE
Add metro transit, familiar creatures, and offline support

### DIFF
--- a/icons/icon-maskable.svg
+++ b/icons/icon-maskable.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <radialGradient id="sky" cx="50%" cy="42%" r="75%">
+      <stop offset="0%" stop-color="#1b1535"/>
+      <stop offset="60%" stop-color="#0d0a1c"/>
+      <stop offset="100%" stop-color="#050309"/>
+    </radialGradient>
+    <radialGradient id="core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff6d8"/>
+      <stop offset="45%" stop-color="#ffc46b"/>
+      <stop offset="100%" stop-color="#ff7a3d" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="128" height="128" fill="url(#sky)"/>
+  <ellipse cx="64" cy="64" rx="34" ry="12" fill="none" stroke="#7fd4ff" stroke-opacity="0.55" stroke-width="2.2" transform="rotate(-24 64 64)"/>
+  <circle cx="64" cy="64" r="13" fill="url(#core)"/>
+  <circle cx="64" cy="64" r="6" fill="#fff3c9"/>
+  <circle cx="92" cy="50" r="2.2" fill="#7fd4ff"/>
+  <circle cx="38" cy="80" r="1.9" fill="#c08bff"/>
+</svg>

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <radialGradient id="sky" cx="50%" cy="42%" r="70%">
+      <stop offset="0%" stop-color="#1b1535"/>
+      <stop offset="60%" stop-color="#0d0a1c"/>
+      <stop offset="100%" stop-color="#050309"/>
+    </radialGradient>
+    <radialGradient id="core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff6d8"/>
+      <stop offset="45%" stop-color="#ffc46b"/>
+      <stop offset="100%" stop-color="#ff7a3d" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#sky)"/>
+  <ellipse cx="64" cy="64" rx="44" ry="16" fill="none" stroke="#7fd4ff" stroke-opacity="0.55" stroke-width="2.5" transform="rotate(-24 64 64)"/>
+  <ellipse cx="64" cy="64" rx="30" ry="10" fill="none" stroke="#c08bff" stroke-opacity="0.45" stroke-width="2" transform="rotate(-24 64 64)"/>
+  <circle cx="64" cy="64" r="17" fill="url(#core)"/>
+  <circle cx="64" cy="64" r="7.5" fill="#fff3c9"/>
+  <circle cx="103" cy="46" r="2.6" fill="#7fd4ff"/>
+  <circle cx="30" cy="86" r="2.2" fill="#c08bff"/>
+  <circle cx="40" cy="30" r="1.7" fill="#ffffff" fill-opacity="0.9"/>
+  <circle cx="96" cy="98" r="1.7" fill="#ffffff" fill-opacity="0.7"/>
+  <circle cx="22" cy="52" r="1.2" fill="#ffffff" fill-opacity="0.6"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,16 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="object-src 'none'; base-uri 'none'; require-trusted-types-for 'script';" />
+    <meta name="theme-color" content="#0b0b12">
     <title>Celestial Canvas</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="manifest" href="manifest.webmanifest">
+    <link rel="icon" href="icons/icon.svg" type="image/svg+xml">
 </head>
 <body>
     <div id="canvas-container">
         <div id="particles-js"></div>
     </div>
     <div id="cursor-glow"></div>
-    
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/particles.js/2.0.0/particles.min.js"></script>
+
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/background.js
+++ b/js/background.js
@@ -408,8 +408,9 @@ class BackgroundSystem {
             this.gradientColors = [`hsl(${this.hue}, 80%, ${l}%)`, `hsl(${this.hue}, 40%, ${l*2}%)`, `hsl(${this.hue}, 90%, ${l*0.5}%)` ];
         } else {
             const shift = Math.sin(this.tick * 0.002) * 20;
-            // Epoch aging slowly biases the sky's hue (epoch_system.js)
-            const h = this.hue + shift + (this.epochHueBias || 0);
+            // Epoch aging and live audio treble both bias the sky's hue.
+            // (audioHueShift was previously computed but never consumed.)
+            const h = this.hue + shift + (this.epochHueBias || 0) + (this.audioHueShift || 0);
             const style = this.gradientStyle || 0;
             if (style === 1) {
                 // Radial: bright center fading to dark edges

--- a/js/background.js
+++ b/js/background.js
@@ -13,6 +13,8 @@ import { speechInput } from './speech_input.js';
 import { cameraInput } from './camera_input.js';
 import { perfMonitor } from './perf_monitor.js';
 import { touchGestures } from './touch_gestures.js';
+import { midiInput } from './midi_input.js';
+import { environmentSense } from './environment_sense.js';
 import { postProcessing } from './post_processing.js';
 import { generativeMusic } from './generative_music.js';
 import { timeline } from './timeline.js';
@@ -117,7 +119,11 @@ class BackgroundSystem {
             }
         });
 
-        const markInteraction = () => { this._lastInteraction = performance.now(); this._idleCycleActive = false; };
+        const markInteraction = () => {
+            this._lastInteraction = performance.now();
+            if (this._idleCycleActive) environmentSense.releaseWakeLock();
+            this._idleCycleActive = false;
+        };
 
         window.addEventListener('mousedown', (e) => {
             markInteraction();
@@ -232,7 +238,11 @@ class BackgroundSystem {
             if (!this._idleCycleActive) {
                 this._idleCycleActive = true;
                 this._lastIdleCycle = now;
+                // Screensaver engaged: keep the display awake while it performs
+                environmentSense.requestWakeLock();
             }
+            // Calm mode: hold the current scene instead of auto-cycling
+            if (environmentSense.reducedMotion) return;
             if (now - this._lastIdleCycle > this._idleCycleInterval) {
                 this._lastIdleCycle = now;
                 // Auto-cycle to random architecture
@@ -459,9 +469,45 @@ class BackgroundSystem {
         this.tabSync = tabSync;
         this.speech = speechInput;
         this.camera = cameraInput;
-        this.qualityScale = perfMonitor.qualityScale;
+        // Quality budget: perf-measured scale capped by battery state
+        this.qualityScale = Math.min(perfMonitor.qualityScale, environmentSense.qualityCap);
         this.pinchScale = touchGestures.pinchScale;
         this.touchRotation = touchGestures.rotation;
+        this.midi = midiInput;
+
+        // Calm mode: prefers-reduced-motion clamps warp speed and idle churn
+        if (environmentSense.reducedMotion && this.targetSpeed > 3) {
+            this.targetSpeed = 3;
+        }
+
+        // MIDI performance hooks: knob 0 drives warp, knob 1 rotates the live
+        // theme hue, mod wheel leans on speed, note-ons strike shockwaves
+        // placed by pitch (x) and velocity (y)
+        if (midiInput.active) {
+            const k0 = midiInput.knobs[0];
+            if (!Number.isNaN(k0)) this.targetSpeed = Math.max(this.targetSpeed, 1 + k0 * 14);
+            const k1 = midiInput.knobs[1];
+            if (!Number.isNaN(k1)) {
+                const want = k1 * 360;
+                const delta = want - (this._midiHuePrev ?? want);
+                if (Math.abs(delta) > 2) {
+                    this.hue = (this.hue + delta + 360) % 360;
+                    this._midiHuePrev = want;
+                    this.updateThemeColors();
+                }
+                if (this._midiHuePrev === undefined) this._midiHuePrev = want;
+            }
+            if (midiInput.modWheel > 0.02) {
+                this.targetSpeed = Math.max(this.targetSpeed, 1 + midiInput.modWheel * 6);
+            }
+            const notes = midiInput.drainNotes();
+            for (const n of notes) {
+                this.createShockwave(
+                    (n.note / 127) * this.width,
+                    this.height * (0.85 - n.velocity * 0.7)
+                );
+            }
+        }
 
         // Touch gesture reactions
         if (touchGestures.swipeDirection) {

--- a/js/background.js
+++ b/js/background.js
@@ -359,6 +359,8 @@ class BackgroundSystem {
         // Cap shockwaves to prevent unbounded growth
         if (this.shockwaves.length >= 15) return;
         this.shockwaves.push({ x, y, radius: 0, maxRadius: Math.max(this.width, this.height) * 0.8, speed: 10, strength: 2, alpha: 1 });
+        // Haptic thump on controllers that support rumble
+        if (!fromRemote) gamepadInput.vibrate(110, 0.35, 0.6);
         // Broadcast to other tabs (normalized coordinates)
         if (!fromRemote && tabSync.tabCount > 1) {
             tabSync.sendEffect('shockwave', { x: x / this.width, y: y / this.height });
@@ -406,7 +408,8 @@ class BackgroundSystem {
             this.gradientColors = [`hsl(${this.hue}, 80%, ${l}%)`, `hsl(${this.hue}, 40%, ${l*2}%)`, `hsl(${this.hue}, 90%, ${l*0.5}%)` ];
         } else {
             const shift = Math.sin(this.tick * 0.002) * 20;
-            const h = this.hue + shift;
+            // Epoch aging slowly biases the sky's hue (epoch_system.js)
+            const h = this.hue + shift + (this.epochHueBias || 0);
             const style = this.gradientStyle || 0;
             if (style === 1) {
                 // Radial: bright center fading to dark edges
@@ -657,6 +660,11 @@ class BackgroundSystem {
 
     applyBGMutators() {
         const ctx = this.ctx;
+        // Late-epoch dimming: the universe gutters as it nears heat death
+        if (this.epochDim > 0.005) {
+            ctx.fillStyle = `rgba(0, 0, 0, ${this.epochDim})`;
+            ctx.fillRect(0, 0, this.width, this.height);
+        }
         if (this.bgMutators.includes('Vignette')) {
             // Cache vignette gradient (only recreate on resize)
             if (!this.cachedVignetteGradient || this.cachedVignetteWidth !== this.width) {

--- a/js/cataclysms.js
+++ b/js/cataclysms.js
@@ -5,6 +5,7 @@
 
 import { ui, universeProfile, physics, setCataclysmInProgress, addActiveInterval, activeEffects, seededRandom } from './state.js';
 import { generateUniverse } from './universe.js';
+import { gamepadInput } from './gamepad_input.js';
 
 /**
  * Triggers a universe-ending cataclysm.
@@ -12,6 +13,7 @@ import { generateUniverse } from './universe.js';
  */
 export function triggerCataclysm(pJS) {
     setCataclysmInProgress(true);
+    gamepadInput.vibrate(800, 1, 1);
     ui.container.classList.remove('visible');
     ui.canvasContainer.classList.remove('shake');
     const choice = universeProfile.cataclysm;

--- a/js/cataclysms.js
+++ b/js/cataclysms.js
@@ -14,7 +14,11 @@ import { gamepadInput } from './gamepad_input.js';
 export function triggerCataclysm(pJS) {
     setCataclysmInProgress(true);
     gamepadInput.vibrate(800, 1, 1);
-    ui.container.classList.remove('visible');
+    // Hide the HUD during the cataclysm. (This used to read ui.container,
+    // which doesn't exist on the state ui object — the resulting TypeError
+    // killed the simulation loop the first time any cataclysm fired.)
+    const hudEl = document.getElementById('ui-container');
+    if (hudEl) hudEl.classList.remove('visible');
     ui.canvasContainer.classList.remove('shake');
     const choice = universeProfile.cataclysm;
     const regen = (delay) => setTimeout(() => generateUniverse(pJS, null, true), delay);
@@ -51,5 +55,16 @@ export function triggerCataclysm(pJS) {
         case 'Homogenization': let homo = 0; const homoInterval = setInterval(() => { homo++; const avg_c = pJS.particles.array.reduce((acc, p) => { acc.r += p.color.rgb.r; acc.g += p.color.rgb.g; acc.b += p.color.rgb.b; return acc; }, {r:0,g:0,b:0}); avg_c.r /= pJS.particles.array.length; avg_c.g /= pJS.particles.array.length; avg_c.b /= pJS.particles.array.length; pJS.particles.array.forEach(p => { p.vx *= 0.95; p.vy *= 0.95; p.color.rgb.r = (p.color.rgb.r*9 + avg_c.r)/10; p.color.rgb.g = (p.color.rgb.g*9 + avg_c.g)/10; p.color.rgb.b = (p.color.rgb.b*9 + avg_c.b)/10; }); if(homo > 200) { clearInterval(homoInterval); regen(1000); } }, 20); addActiveInterval(homoInterval); break;
         case 'Banishing': pJS.particles.array.forEach(p => { p.vx = (seededRandom()-0.5)*5; p.vy = (seededRandom()-0.5)*5 - 20; p.opacity.value = 1; }); regen(4000); break;
         case 'TidalWave': let wavePos = -100; const waveInterval = setInterval(() => { wavePos += 20; pJS.particles.array.forEach(p => { if (p.x < wavePos && p.x > wavePos - 40) { p.vx += 15; p.vy += (seededRandom() - 0.5) * 5; } }); if (wavePos > pJS.canvas.w + 100) { clearInterval(waveInterval); regen(1000); } }, 20); addActiveInterval(waveInterval); break;
+        // Gravity flips and the sky drains upward into a spin.
+        case 'Inversion': { let inv = 0; const invInterval = setInterval(() => { inv++; const cx = pJS.canvas.w / 2, cy = pJS.canvas.h / 2; for (const p of pJS.particles.array) { const dx = p.x - cx, dy = p.y - cy; const a = 0.002 + inv * 0.0004; p.vx += -dy * a + dx * 0.001; p.vy += dx * a + dy * 0.001 - 0.15; } if (inv > 120) { clearInterval(invInterval); regen(1500); } }, 20); addActiveInterval(invInterval); break; }
+        // Every star falls out of the firmament, bounces, and dies in a final burst.
+        case 'StarFall': { let fall = 0; const floor = pJS.canvas.h - 8; const fallInterval = setInterval(() => { fall++; for (const p of pJS.particles.array) { p.vy += 1.4; if (p.y >= floor && p.vy > 0) { p.y = floor; p.vy *= -0.55; p.vx *= 0.9; } } if (fall > 110) { for (const p of pJS.particles.array) { p.vx = (seededRandom() - 0.5) * 40; p.vy = -seededRandom() * 35; } clearInterval(fallInterval); regen(1800); } }, 20); addActiveInterval(fallInterval); break; }
+        // Safety net: an unknown cataclysm name must never strand the universe
+        // in cataclysmInProgress forever — fade out and regenerate.
+        default: {
+            console.warn(`[cataclysms] Unknown cataclysm "${choice}" — regenerating.`);
+            pJS.particles.array.forEach(p => { p.fading = 120; });
+            regen(2500);
+        }
     }
 }

--- a/js/cursor_familiar.js
+++ b/js/cursor_familiar.js
@@ -1,0 +1,223 @@
+/**
+ * @file cursor_familiar.js
+ * @description The cursor familiar: every universe hatches one small companion
+ * creature that lives at your cursor. It spring-follows with species-specific
+ * locomotion, gets visibly excited when you move fast, dozes off (dims, slows,
+ * settles) when you go idle, and startles when you click.
+ *
+ * This replaces the old generic inline effects (click ripples, mouse-trail
+ * ribbon, gravity field lines, heat map, echo ghosts, constellation links)
+ * with one cohesive, characterful system. Trails and glows already have
+ * dedicated layers (cursor_trails.js / cursor_effects.js); the familiar is a
+ * creature, not a trail.
+ *
+ * Seed-driven variation: species (6, weighted toward the active blueprint),
+ * size, palette hues, follow lag and offset, doze threshold, plus all
+ * species-internal anatomy (moth count, serpent length, shard shells...).
+ */
+
+import { FAMILIAR_SPECIES, selectSpecies } from './familiar_species.js';
+
+const TAU = Math.PI * 2;
+
+const MAX_TRAIL = 70;
+
+class CursorFamiliar {
+    constructor() {
+        this.species = FAMILIAR_SPECIES[0];
+        this.x = 0;
+        this.y = 0;
+        this.vx = 0;
+        this.vy = 0;
+        this.heading = 0;
+        this.speed = 0;
+        this.excitement = 0;
+        this.mode = 'follow';
+        this.startleT = 0;
+        this.dozeT = 0;
+        this.size = 6;
+        this.hue = 200;
+        this.hue2 = 60;
+        this.tick = 0;
+        this.aux = null;
+
+        this._idleTicks = 0;
+        this._dozeAfter = 360;
+        this._followK = 0.05;
+        this._damping = 0.82;
+        this._offsetAng = 0;
+        this._offsetR = 0;
+        this._wasClicking = false;
+        this._prevMx = 0;
+        this._prevMy = 0;
+        this._inited = false;
+        this._lcg = 1;
+        this.rand = () => {
+            this._lcg = (Math.imul(this._lcg, 1664525) + 1013904223) >>> 0;
+            return this._lcg / 4294967296;
+        };
+
+        // Pooled trail particles, styled per species (ember/petal/spark/ink/ring)
+        this._trail = [];
+        this._trailPool = [];
+        this.emit = (style, x, y, vx, vy, life, size) => {
+            if (this._trail.length >= MAX_TRAIL) return;
+            const p = this._trailPool.length > 0 ? this._trailPool.pop() : {};
+            p.style = style;
+            p.x = x; p.y = y; p.vx = vx; p.vy = vy;
+            p.life = life; p.maxLife = life; p.size = size;
+            this._trail.push(p);
+        };
+    }
+
+    configure(rng, hues, blueprintName) {
+        this.species = selectSpecies(rng, blueprintName || '');
+        this.size = 4.5 + rng() * 4;
+        this.hue = hues && hues.length > 0 ? hues[0].h : rng() * 360;
+        this.hue2 = hues && hues.length > 1 ? hues[1].h : (this.hue + 150) % 360;
+        this._followK = 0.035 + rng() * 0.04;
+        this._damping = 0.78 + rng() * 0.08;
+        this._dozeAfter = 300 + Math.floor(rng() * 360);
+        // Familiars hover beside the cursor, not on top of it
+        this._offsetAng = rng() * TAU;
+        this._offsetR = 26 + rng() * 22;
+        this._lcg = ((rng() * 4294967296) >>> 0) || 1;
+
+        this.tick = 0;
+        this.mode = 'follow';
+        this.startleT = 0;
+        this.dozeT = 0;
+        this.excitement = 0;
+        this._idleTicks = 0;
+        this._inited = false;
+        this._trail.length = 0;
+
+        this.species.init(this, rng);
+    }
+
+    update(mx, my, isClicking) {
+        this.tick++;
+
+        if (!this._inited) {
+            this._inited = true;
+            this.x = mx;
+            this.y = my;
+            this._prevMx = mx;
+            this._prevMy = my;
+        }
+
+        // Cursor activity → excitement + idle tracking
+        const mdx = mx - this._prevMx;
+        const mdy = my - this._prevMy;
+        const mouseSpeed = Math.hypot(mdx, mdy);
+        this._prevMx = mx;
+        this._prevMy = my;
+        this.excitement += (Math.min(1, mouseSpeed / 18) - this.excitement) * 0.06;
+        if (mouseSpeed > 1.5 || isClicking) this._idleTicks = 0;
+        else this._idleTicks++;
+
+        // Startle on click edge
+        if (isClicking && !this._wasClicking) {
+            this.startleT = 1;
+            this.mode = 'follow';
+            this._idleTicks = 0;
+        }
+        this._wasClicking = isClicking;
+        if (this.startleT > 0) this.startleT = Math.max(0, this.startleT - 0.025);
+
+        // Doze state eases in and out
+        const dozing = this._idleTicks > this._dozeAfter;
+        this.mode = this.startleT > 0.5 ? 'startle' : dozing ? 'doze' : 'follow';
+        this.dozeT += ((dozing ? 1 : 0) - this.dozeT) * 0.02;
+
+        // Spring-follow a perch point near the cursor; the offset drifts so the
+        // familiar circles you while you work
+        this._offsetAng += 0.004 + this.excitement * 0.01;
+        const perchR = this._offsetR * (1 - this.dozeT * 0.4) * (1 - this.excitement * 0.5);
+        const tx = mx + Math.cos(this._offsetAng) * perchR;
+        const ty = my + Math.sin(this._offsetAng) * perchR * 0.7;
+        const k = this._followK * (this.mode === 'startle' ? 2.2 : 1) * (1 - this.dozeT * 0.7);
+        this.vx = (this.vx + (tx - this.x) * k) * this._damping;
+        this.vy = (this.vy + (ty - this.y) * k) * this._damping;
+        this.x += this.vx;
+        this.y += this.vy;
+
+        this.speed = Math.hypot(this.vx, this.vy);
+        if (this.speed > 0.3) {
+            const targetHeading = Math.atan2(this.vy, this.vx);
+            let d = (targetHeading - this.heading) % TAU;
+            if (d > Math.PI) d -= TAU;
+            if (d < -Math.PI) d += TAU;
+            this.heading += d * 0.2;
+        }
+
+        this.species.update(this);
+
+        // Trail particles
+        for (let i = this._trail.length - 1; i >= 0; i--) {
+            const p = this._trail[i];
+            p.x += p.vx;
+            p.y += p.vy;
+            p.vx *= 0.97;
+            p.vy *= 0.97;
+            p.life--;
+            if (p.life <= 0) {
+                this._trailPool.push(p);
+                this._trail[i] = this._trail[this._trail.length - 1];
+                this._trail.pop();
+            }
+        }
+    }
+
+    draw(ctx, system) {
+        // Trail behind the body so the creature reads on top
+        if (this._trail.length > 0) this._drawTrail(ctx);
+        this.species.draw(ctx, this);
+
+        // Doze tell: drifting 'z' sparkles
+        if (this.dozeT > 0.6 && this.tick % 90 < 2) {
+            this.emit('spark', this.x + 8, this.y - 10, 0.15, -0.35, 70, 1.4);
+        }
+    }
+
+    _drawTrail(ctx) {
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        for (const p of this._trail) {
+            const t = p.life / p.maxLife;
+            switch (p.style) {
+                case 'ember':
+                    ctx.fillStyle = `hsla(${this.hue}, 95%, ${55 + t * 30}%, ${t * 0.7})`;
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, p.size * t, 0, TAU);
+                    ctx.fill();
+                    break;
+                case 'petal':
+                    ctx.fillStyle = `hsla(${this.hue2}, 70%, 78%, ${t * 0.5})`;
+                    ctx.fillRect(p.x - p.size, p.y - p.size * 0.4, p.size * 2, p.size * 0.8);
+                    break;
+                case 'ink':
+                    ctx.fillStyle = `hsla(${this.hue}, 60%, 25%, ${t * 0.5})`;
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, p.size * (1.6 - t * 0.6), 0, TAU);
+                    ctx.fill();
+                    break;
+                case 'ring': {
+                    const r = p.size * (1.4 - t) * 3;
+                    ctx.strokeStyle = `hsla(${this.hue2}, 90%, 70%, ${t * 0.6})`;
+                    ctx.lineWidth = 1.5;
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, r, 0, TAU);
+                    ctx.stroke();
+                    break;
+                }
+                default: // spark
+                    ctx.fillStyle = `hsla(${this.hue2}, 90%, 85%, ${t * 0.8})`;
+                    ctx.fillRect(p.x - p.size / 2, p.y - p.size / 2, p.size, p.size);
+            }
+        }
+        ctx.restore();
+    }
+}
+
+export const cursorFamiliar = new CursorFamiliar();

--- a/js/cursor_familiar.js
+++ b/js/cursor_familiar.js
@@ -17,6 +17,7 @@
  */
 
 import { FAMILIAR_SPECIES, selectSpecies } from './familiar_species.js';
+import { familiarMemory } from './familiar_memory.js';
 
 const TAU = Math.PI * 2;
 
@@ -36,6 +37,7 @@ class CursorFamiliar {
         this.startleT = 0;
         this.dozeT = 0;
         this.size = 6;
+        this.stage = 0;
         this.hue = 200;
         this.hue2 = 60;
         this.tick = 0;
@@ -72,7 +74,10 @@ class CursorFamiliar {
 
     configure(rng, hues, blueprintName) {
         this.species = selectSpecies(rng, blueprintName || '');
-        this.size = 4.5 + rng() * 4;
+        // Familiars grow with cumulative play time across visits (familiar_memory.js)
+        const stage = familiarMemory.loaded ? familiarMemory.stage : 0;
+        this.stage = stage;
+        this.size = (4.5 + rng() * 4) * (0.85 + stage * 0.12);
         this.hue = hues && hues.length > 0 ? hues[0].h : rng() * 360;
         this.hue2 = hues && hues.length > 1 ? hues[1].h : (this.hue + 150) % 360;
         this._followK = 0.035 + rng() * 0.04;
@@ -115,6 +120,9 @@ class CursorFamiliar {
         this.excitement += (Math.min(1, mouseSpeed / 18) - this.excitement) * 0.06;
         if (mouseSpeed > 1.5 || isClicking) this._idleTicks = 0;
         else this._idleTicks++;
+
+        // Time genuinely spent together feeds long-term growth
+        if (this.excitement > 0.05) familiarMemory.recordActivity();
 
         // Startle on click edge
         if (isClicking && !this._wasClicking) {
@@ -172,6 +180,20 @@ class CursorFamiliar {
     draw(ctx, system) {
         // Trail behind the body so the creature reads on top
         if (this._trail.length > 0) this._drawTrail(ctx);
+
+        // Venerable+ familiars carry a faint breathing aura
+        if (this.stage >= 3) {
+            const auraR = this.size * (2.6 + Math.sin(this.tick * 0.04) * 0.4) * (1 - this.dozeT * 0.3);
+            ctx.save();
+            ctx.globalCompositeOperation = 'lighter';
+            ctx.strokeStyle = `hsla(${this.hue2}, 80%, 75%, ${this.stage >= 4 ? 0.22 : 0.12})`;
+            ctx.lineWidth = 1.2;
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, auraR, 0, TAU);
+            ctx.stroke();
+            ctx.restore();
+        }
+
         this.species.draw(ctx, this);
 
         // Doze tell: drifting 'z' sparkles

--- a/js/drawing.js
+++ b/js/drawing.js
@@ -286,6 +286,25 @@ function drawCoralConnections(ctx) {
     });
 }
 
+function drawCosmicStrings(ctx, tick) {
+    activeEffects.cosmicStrings.forEach(s => {
+        const shimmer = 0.22 + Math.sin(tick * 0.05 + s.x1 * 0.01) * 0.12;
+        ctx.strokeStyle = `rgba(220, 230, 255, ${shimmer})`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(s.x1, s.y1);
+        ctx.lineTo(s.x2, s.y2);
+        ctx.stroke();
+        // Anchor glints
+        ctx.fillStyle = `rgba(230, 240, 255, ${shimmer + 0.25})`;
+        ctx.beginPath();
+        ctx.arc(s.x1, s.y1, 2, 0, 2 * Math.PI);
+        ctx.moveTo(s.x2 + 2, s.y2);
+        ctx.arc(s.x2, s.y2, 2, 0, 2 * Math.PI);
+        ctx.fill();
+    });
+}
+
 function drawCosmicRivers(ctx) {
     activeEffects.cosmicRivers.forEach(river => {
         ctx.strokeStyle = 'rgba(150, 200, 255, 0.1)';
@@ -336,6 +355,7 @@ export function drawEffects(ctx) {
     drawEchoingVoids(ctx);
     drawCosmicNurseries(ctx);
     drawCoralConnections(ctx);
+    drawCosmicStrings(ctx, tick);
     drawCosmicRivers(ctx);
 
     if (useBloom) {

--- a/js/effect_registry.js
+++ b/js/effect_registry.js
@@ -102,6 +102,7 @@ import { ChromaticWake } from './chromatic_wake_effects.js';
 import { ParticleFountain } from './particle_fountain_effects.js';
 import { RuneSigils } from './rune_sigil_effects.js';
 import { KiteFestival } from './kite_festival_effects.js';
+import { MetroTransit } from './metro_transit_effects.js';
 
 /**
  * Blueprint-to-tag mapping. Each blueprint has a set of theme tags that describe
@@ -247,6 +248,7 @@ export const EFFECT_REGISTRY = [
     { instance: new ParticleFountain(),    tags: ['fire', 'stellar', 'physics'],            minQuality: 0.25, drawOrder: 91 },
     { instance: new RuneSigils(),          tags: ['ethereal', 'geometric', 'dark'],          minQuality: 0.3,  drawOrder: 92 },
     { instance: new KiteFestival(),        tags: ['ethereal', 'painterly', 'geometric'],     minQuality: 0.3,  drawOrder: 93 },
+    { instance: new MetroTransit(),        tags: ['tech', 'digital', 'geometric'],           minQuality: 0.25, drawOrder: 94 },
 ];
 
 // Pre-create tag Sets for O(1) intersection

--- a/js/effects.js
+++ b/js/effects.js
@@ -33,17 +33,17 @@ import { postProcess } from './post_processing.js';
  */
 export const universeBlueprints = {
     // A classic space simulation with gravitational pull and explosive events.
-    Classical: { left:['comet'], right:['supernova','gravityWell'], events:['binaryStars','meteorShower'], cataclysms:['Supernova'], aesthetic:{glow:true, trails:false, shape:['circle','star'], physics:{attract:true, straight:false, bounce:false, friction:0.98}} },
+    Classical: { left:['comet'], right:['supernova','gravityWell'], events:['binaryStars','meteorShower'], cataclysms:['Supernova', 'StarFall'], aesthetic:{glow:true, trails:false, shape:['circle','star'], physics:{attract:true, straight:false, bounce:false, friction:0.98}} },
     // A fluid, biological environment with interactive, symbiotic particles.
     Organic: { left:['symbiote','forceField'], right:['sculptor','setOrbit'], events:['pulsingCore', 'sporeRelease'], cataclysms:['Phase Shift'], aesthetic:{glow:false, trails:true, shape:['circle'], physics:{attract:true, straight:false, bounce:false, friction:0.98}} },
     Digital: { left:['chainLightning','shaper','scribe'], right:['glitch','toggleLinks'], events:['cosmicMessage'], cataclysms:['Glitch Storm'], aesthetic:{glow:true, trails:false, shape:['character'], chars:['0','1','<','>','/','?'], physics:{attract:false, straight:true, bounce:false, friction:0.98}} },
     Crystalline: { left: ['shatter', 'refractor'], right: ['crystalize', 'glaze'], events: ['crystalGrowth'], cataclysms: ['Resonance Cascade'], aesthetic:{glow:true, trails:false, shape:['triangle', 'edge'], physics:{attract:false, straight:true, bounce:true, friction:1}} },
     BioMechanical: { left: ['infect', 'tendril'], right: ['harvest', 'toggleLinks'], events: ['neuronPulse', 'sporeRelease'], cataclysms: ['Overgrowth'], aesthetic:{glow:true, trails:true, shape:['polygon'], physics:{attract:true, straight:false, bounce:true, friction:0.96}} },
-    ChronoVerse: { left: ['accelerate'], right: ['stasisField'], events: ['temporalEchoes'], cataclysms: ['Time Collapse'], aesthetic:{glow:true, trails:true, shape:['circle'], physics:{attract:false, straight:false, bounce:false, friction:0.97}} },
+    ChronoVerse: { left: ['accelerate'], right: ['stasisField'], events: ['temporalEchoes'], cataclysms: ['Time Collapse', 'Inversion'], aesthetic:{glow:true, trails:true, shape:['circle'], physics:{attract:false, straight:false, bounce:false, friction:0.97}} },
     VoidTouched: { left: ['voidRift','void'], right: ['unravel'], events: ['flickeringReality'], cataclysms: ['Total Annihilation'], aesthetic:{glow:true, trails:false, shape:['circle', 'edge'], monochrome:true, physics:{attract:true, straight:true, bounce:false, friction:0.98}} },
     PhantomEcho: { left: ['echoPulse'], right: ['phaseZone'], events: ['dejaVu'], cataclysms: ['Causality Collapse'], aesthetic:{glow:true, trails:false, shape:['circle'], physics:{attract:false, straight:false, bounce:false, friction:0.97}} },
     Aetherial: { left: ['whisper', 'fade'], right: ['paint', 'wormhole'], events: ['aurora'], cataclysms: ['Great Fading'], aesthetic:{glow:true, trails:true, shape:['circle'], opacity: 0.3, physics:{attract:false, straight:false, bounce:false, friction:0.99}}},
-    QuantumFoam: { left: ['observe', 'quantumTunnel'], right: ['entangle', 'decohere'], events: ['probabilityFlux'], cataclysms: ['False Vacuum Decay'], aesthetic:{glow:true, trails:false, shape:['edge', 'triangle'], physics:{attract:false, straight:true, bounce:true, friction:0.99}} },
+    QuantumFoam: { left: ['observe', 'quantumTunnel'], right: ['entangle', 'decohere'], events: ['probabilityFlux'], cataclysms: ['False Vacuum Decay', 'Inversion'], aesthetic:{glow:true, trails:false, shape:['edge', 'triangle'], physics:{attract:false, straight:true, bounce:true, friction:0.99}} },
     SonicScapes: { left: ['resonate', 'dampen'], right: ['shockwave', 'silence'], events: ['ambientHum'], cataclysms: ['The Great Silence'], aesthetic:{glow:true, trails:true, shape:['edge'], opacity: 0.6, physics:{attract:false, straight:false, bounce:true, friction:0.97}} },
     LivingInk: { left: ['smudge', 'draw'], right: ['splatter', 'blot'], events: ['inkSeep'], cataclysms: ['The Bleed'], aesthetic:{glow:false, trails:true, shape:['circle'], physics:{attract:false, straight:false, bounce:false, friction:0.92}} },
     Eldritch: { left: ['consume', 'maddeningWhisper'], right: ['gaze', 'realityTear'], events: ['nonEuclideanShift'], cataclysms: ['UnseenGibbering'], aesthetic:{glow:true, trails:true, shape:['polygon'], sides: 7, monochrome: true, physics:{attract:true, straight:false, bounce:false, friction:0.95}} },
@@ -54,12 +54,12 @@ export const universeBlueprints = {
     GlacialDrift: { left:['glacier'], right:['flashFreeze'], events:['crystalGrowth'], cataclysms:['DeepFreeze'], aesthetic:{glow:true, trails:false, shape:['edge', 'triangle'], physics:{attract:false, straight:true, bounce:true, friction:0.99}} },
     SentientSwarm: { left:['swarmFollow'], right:['disperse'], events:['neuronPulse'], cataclysms:['HiveCollapse'], aesthetic:{glow:true, trails:false, shape:['circle'], physics:{attract:true, straight:false, bounce:false, friction:0.95}} },
     StellarNursery: { left:['gatherDust', 'ignite'], right:['supernova', 'whiteHoleSpawn'], events:['binaryStars', 'meteorShower'], cataclysms:['ProtoStarCollapse', 'Supernova'], aesthetic:{glow:true, trails:true, shape:['star', 'circle'], physics:{attract:true, straight:false, bounce:false, friction:0.98}} },
-    AbyssalZone: { left:['lure', 'crush'], right:['pressureWave', 'silence'], events:['bioluminescence'], cataclysms:['BenthicStorm', 'TheGreatSilence'], aesthetic:{glow:true, trails:false, shape:['polygon'], sides:8, monochrome:true, physics:{attract:true, straight:false, bounce:false, friction:0.8}} },
-    TechnoUtopia: { left:['align', 'regrid'], right:['glitch', 'toggleLinks'], events:['cosmicMessage'], cataclysms:['SystemCrash', 'GlitchStorm'], aesthetic:{glow:true, trails:false, shape:['edge', 'character'], chars:['|','_','[',']','{','}'], physics:{attract:false, straight:true, bounce:true, friction:1}} },
+    AbyssalZone: { left:['lure', 'crush'], right:['pressureWave', 'silence'], events:['bioluminescence'], cataclysms:['BenthicStorm', 'The Great Silence'], aesthetic:{glow:true, trails:false, shape:['polygon'], sides:8, monochrome:true, physics:{attract:true, straight:false, bounce:false, friction:0.8}} },
+    TechnoUtopia: { left:['align', 'regrid'], right:['glitch', 'toggleLinks'], events:['cosmicMessage'], cataclysms:['SystemCrash', 'Glitch Storm'], aesthetic:{glow:true, trails:false, shape:['edge', 'character'], chars:['|','_','[',']','{','}'], physics:{attract:false, straight:true, bounce:true, friction:1}} },
     FungalForest: { left:['sporeBurst', 'tangle'], right:['overgrow', 'decompose'], events:['sporeRelease', 'neuronPulse'], cataclysms:['Decomposition', 'Overgrowth'], aesthetic:{glow:false, trails:true, shape:['circle', 'polygon'], sides:3, physics:{attract:true, straight:false, bounce:false, friction:0.92}} },
     GlassySea: { left:['ripple', 'freeze'], right:['shatter', 'focus'], events:['aurora'], cataclysms:['Shattering', 'DeepFreeze'], aesthetic:{glow:true, trails:false, shape:['edge', 'triangle'], opacity:0.4, physics:{attract:false, straight:false, bounce:true, friction:0.99}} },
     Papercraft: { left:['fold', 'crease'], right:['paperTear', 'smooth'], events:['ambientHum'], cataclysms:['PaperTearCataclysm', 'CanvasWipe'], aesthetic:{glow:false, trails:false, shape:['edge'], physics:{attract:false, straight:true, bounce:false, friction:0.94}} },
-    ChromaticAberration: { left:['prism', 'focus'], right:['aberrate', 'wash'], events:['colorBleed'], cataclysms:['ColorBurn', 'PhaseShift'], aesthetic:{glow:true, trails:true, shape:['circle'], physics:{attract:false, straight:false, bounce:false, friction:0.97}} },
+    ChromaticAberration: { left:['prism', 'focus'], right:['aberrate', 'wash'], events:['colorBleed'], cataclysms:['ColorBurn', 'Phase Shift'], aesthetic:{glow:true, trails:true, shape:['circle'], physics:{attract:false, straight:false, bounce:false, friction:0.97}} },
     // New Blueprints
     SilkWeaver: { left:['weaveThread'], right:['pullThreads'], events:['neuronPulse'], cataclysms:['WebCollapse'], aesthetic:{glow:true, trails:false, shape:['circle'], physics:{attract:false, straight:false, bounce:true, friction:0.99}} },
     VolcanicForge: { left:['stokeFire'], right:['quench', 'lavaJet'], events:['meteorShower'], cataclysms:['GrandCooling', 'CoreEruption'], aesthetic:{glow:false, trails:true, shape:['star'], physics:{attract:true, straight:false, bounce:false, friction:0.9}} },
@@ -68,8 +68,8 @@ export const universeBlueprints = {
     HauntedRealm: { left:['exorcise'], right:['materialize', 'phaseZone'], events:['flickeringReality', 'dejaVu'], cataclysms:['Banishing'], aesthetic:{glow:true, trails:true, shape:['circle'], opacity: 0.2, physics:{attract:false, straight:true, bounce:false, friction:0.99}} },
     CoralReef: { left:['growCoral'], right:['schooling'], events:['bioluminescence'], cataclysms:['TidalWave'], aesthetic:{glow:true, trails:false, shape:['polygon'], sides: 6, physics:{attract:true, straight:false, bounce:true, friction:0.92}} },
     NeonCyber: { left:['shaper'], right:['glitch'], events:['cosmicMessage'], cataclysms:['SystemCrash'], aesthetic:{glow:true, trails:true, shape:['edge'], physics:{attract:false, straight:true, bounce:true, friction:1}} },
-    AbyssalHorror: { left:['tendril'], right:['consume'], events:['flickeringReality'], cataclysms:['TotalAnnihilation'], aesthetic:{glow:false, trails:true, shape:['circle'], monochrome:true, physics:{attract:true, straight:false, bounce:false, friction:0.94}} },
-    CelestialForge: { left:['ignite'], right:['supernova'], events:['meteorShower'], cataclysms:['CoreEruption'], aesthetic:{glow:true, trails:true, shape:['star'], physics:{attract:true, straight:false, bounce:false, friction:0.96}} }
+    AbyssalHorror: { left:['tendril'], right:['consume'], events:['flickeringReality'], cataclysms:['Total Annihilation'], aesthetic:{glow:false, trails:true, shape:['circle'], monochrome:true, physics:{attract:true, straight:false, bounce:false, friction:0.94}} },
+    CelestialForge: { left:['ignite'], right:['supernova'], events:['meteorShower'], cataclysms:['CoreEruption', 'StarFall'], aesthetic:{glow:true, trails:true, shape:['star'], physics:{attract:true, straight:false, bounce:false, friction:0.96}} }
 };
 
 /**
@@ -137,6 +137,25 @@ export const mutators = {
     'Inverted': () => { postProcess.setFilter('invert', 1); },
     'Bloom': () => { postProcess.setFilter('blur', 2); },
     'Overexposed': () => { postProcess.setFilter('brightness', 1.5); postProcess.setFilter('saturate', 2); },
+
+    // Two opposing winds shear the universe apart along a seeded axis.
+    'Crosswinds': (pJS, seededRandom, { photonSails }) => {
+        const angle = seededRandom() * Math.PI * 2;
+        const strength = 0.02 + seededRandom() * 0.03;
+        photonSails.push({ angle, strength });
+        photonSails.push({ angle: angle + Math.PI + (seededRandom() - 0.5) * 0.6, strength });
+    },
+    // A deep lateral current drags everything sideways through thick water.
+    'Undertow': (pJS, seededRandom, { tidalForces }, physics) => {
+        tidalForces.push({ y: pJS.canvas.h * (0.4 + seededRandom() * 0.2), strength: 0.25 + seededRandom() * 0.3 });
+        physics.friction = Math.min(physics.friction, 0.93);
+    },
+    // Barely-there particles with long phosphor wakes.
+    'Ghostly': (pJS) => { pJS.particles.opacity.value = 0.22; pJS.particles.move.trail.enable = true; pJS.particles.move.trail.length = 14; },
+    // Everything painted in slow drying ink.
+    'Inkwash': (pJS) => { pJS.particles.move.trail.enable = true; pJS.particles.move.trail.length = 25; pJS.particles.move.speed *= 0.8; },
+    // A pocket cosmos: tiny, quick, busy.
+    'Microcosm': (pJS) => { pJS.particles.size.value *= 0.6; pJS.particles.move.speed *= 1.6; },
 };
 
 /**
@@ -240,5 +259,176 @@ export const anomalies = {
             strength: 0.5 + r() * 1.0,
             width: 30 + r() * 40
         });
+    },
+    // Two quasars facing each other across the void, firing in opposition.
+    'Twin Quasars': (pJS, r, { quasars }) => {
+        const x = pJS.canvas.w * (0.15 + r() * 0.2);
+        const y = pJS.canvas.h * (0.2 + r() * 0.6);
+        const angle = r() * 2 * Math.PI;
+        const period = 150 + r() * 150;
+        quasars.push({ x, y, angle, strength: 15 + r() * 15, period, duration: 20 + r() * 20, tick: 0, isFiring: false });
+        quasars.push({ x: pJS.canvas.w - x, y: pJS.canvas.h - y, angle: angle + Math.PI, strength: 15 + r() * 15, period, duration: 20 + r() * 20, tick: Math.floor(period / 2), isFiring: false });
+    },
+    // A black hole and a white hole locked in a conveyor: matter drains one
+    // side of the sky and erupts from the other.
+    'Tidal Pair': (pJS, r, { blackHoles, whiteHoles }) => {
+        blackHoles.push({ x: pJS.canvas.w * (0.15 + r() * 0.15), y: pJS.canvas.h * (0.25 + r() * 0.5), mass: 80 + r() * 120, eventHorizon: 8 + r() * 10 });
+        whiteHoles.push({ x: pJS.canvas.w * (0.7 + r() * 0.15), y: pJS.canvas.h * (0.25 + r() * 0.5), strength: 4 + r() * 6, spawnRate: 0.05 + r() * 0.1, tick: 0 });
+    },
+    // A field of geysers erupting in staggered rhythm along the floor.
+    'Geyser Field': (pJS, r, { cosmicGeysers }) => {
+        for (let i = 0; i < 3; i++) {
+            cosmicGeysers.push({ x: pJS.canvas.w * (0.15 + i * 0.3 + r() * 0.1), y: pJS.canvas.h, strength: 5 + r() * 8, period: 150 + r() * 200, tick: Math.floor(r() * 150), width: 40 + r() * 40 });
+        }
+    },
+    // Web nodes arranged in a ring; particles caught inside circulate forever.
+    'Maelstrom Web': (pJS, r, { cosmicWebs }) => {
+        const cx = pJS.canvas.w * (0.3 + r() * 0.4);
+        const cy = pJS.canvas.h * (0.3 + r() * 0.4);
+        const radius = 120 + r() * 120;
+        const nodes = [];
+        const count = 7;
+        for (let i = 0; i < count; i++) {
+            const a = (i / count) * Math.PI * 2;
+            nodes.push({ x: cx + Math.cos(a) * radius, y: cy + Math.sin(a) * radius });
+        }
+        cosmicWebs.push({ nodes, strength: 0.15 + r() * 0.15 });
     }
+};
+
+/**
+ * @callback AmbientEvent
+ * @param {object} pJS - The particle engine instance.
+ * @param {function(): number} seededRandom - The seeded random number generator.
+ * @param {object} activeEffects - The active effects object.
+ */
+
+/**
+ * Ambient events: each universe's blueprint picks one (profile.ambientEvent),
+ * and the simulation fires it on a seeded interval. Every effect here is
+ * transient — it either uses an activeEffects array with a lifetime, or
+ * nudges particle properties that already decay (radius swell, fading,
+ * velocity), so repeated firings never accumulate permanent damage.
+ * @type {Object.<string, AmbientEvent>}
+ */
+export const ambientEvents = {
+    // A heavy pair waltzes through, dragging neighbors via the isHeavy force.
+    'binaryStars': (pJS, r) => {
+        if (pJS.particles.array.length + 2 > pJS.particles.number.value_max) return;
+        const cx = pJS.canvas.w * (0.3 + r() * 0.4);
+        const cy = pJS.canvas.h * (0.3 + r() * 0.4);
+        const made = pJS.fn.modes.pushParticles(2, { x: cx, y: cy });
+        made.forEach((p, i) => {
+            const side = i === 0 ? 1 : -1;
+            p.x = cx + side * 18;
+            p.vx = 0; p.vy = side * 2.2;
+            p.isHeavy = true;
+            p.radius = p.radius_initial = 5;
+            p.fading = 400;
+        });
+    },
+    'meteorShower': (pJS, r) => {
+        const n = Math.min(6, pJS.particles.number.value_max - pJS.particles.array.length);
+        for (let i = 0; i < n; i++) {
+            const p = pJS.fn.modes.pushParticles(1, { x: r() * pJS.canvas.w, y: -10 })[0];
+            if (p) { p.vx = 4 + r() * 6; p.vy = 6 + r() * 8; p.fading = 150; }
+        }
+    },
+    'pulsingCore': (pJS, r, { echoPulses }) => {
+        echoPulses.push({ x: pJS.canvas.w / 2, y: pJS.canvas.h / 2, radiusSq: 160000, maxLife: 90, life: 90 });
+    },
+    'sporeRelease': (pJS, r) => {
+        const n = Math.min(5, pJS.particles.number.value_max - pJS.particles.array.length);
+        for (let i = 0; i < n; i++) {
+            const p = pJS.fn.modes.pushParticles(1, { x: r() * pJS.canvas.w, y: r() * pJS.canvas.h })[0];
+            if (p) { p.radius = 1.5; p.vy = -0.5 - r(); p.fading = 200; }
+        }
+    },
+    // A passing transmission: a handful of particles flash into glyphs of light.
+    'cosmicMessage': (pJS, r) => {
+        const arr = pJS.particles.array;
+        for (let i = 0; i < 8 && arr.length > 0; i++) {
+            const p = arr[Math.floor(r() * arr.length)];
+            p.radius = Math.min(p.radius_initial * 2.5, p.radius + 2);
+            p.vx = 0; p.vy = 0;
+        }
+    },
+    'crystalGrowth': (pJS, r, { stasisFields }) => {
+        stasisFields.push({ x: r() * pJS.canvas.w, y: r() * pJS.canvas.h, r: 90 + r() * 60, maxLife: 240, life: 240 });
+    },
+    'neuronPulse': (pJS, r, { echoPulses }) => {
+        const arr = pJS.particles.array;
+        if (arr.length === 0) return;
+        const p = arr[Math.floor(r() * arr.length)];
+        echoPulses.push({ x: p.x, y: p.y, radiusSq: 62500, maxLife: 80, life: 80 });
+    },
+    'temporalEchoes': (pJS, r, { temporalRifts }) => {
+        temporalRifts.push({ x: r() * pJS.canvas.w, y: r() * pJS.canvas.h, radius: 80 + r() * 60, life: 360, maxLife: 360 });
+    },
+    'flickeringReality': (pJS, r, { phaseZones }) => {
+        for (let i = 0; i < 3; i++) {
+            phaseZones.push({ x: r() * pJS.canvas.w, y: r() * pJS.canvas.h, radiusSq: 14400, maxLife: 150, life: 150 });
+        }
+    },
+    'dejaVu': (pJS, r, { echoPulses }) => {
+        const x = r() * pJS.canvas.w;
+        const y = r() * pJS.canvas.h;
+        echoPulses.push({ x, y, radiusSq: 40000, maxLife: 80, life: 80 });
+        echoPulses.push({ x, y, radiusSq: 40000, maxLife: 140, life: 140 });
+    },
+    'aurora': (pJS, r, { spacetimeFoam }) => {
+        for (let i = 0; i < 6; i++) {
+            spacetimeFoam.push({ x: pJS.canvas.w * (i + r()) / 6, y: pJS.canvas.h * (0.1 + r() * 0.2), radius: 30 + r() * 30, life: 200 + r() * 100 });
+        }
+    },
+    'probabilityFlux': (pJS, r) => {
+        const arr = pJS.particles.array;
+        for (let i = 0; i < 10 && arr.length > 0; i++) {
+            const p = arr[Math.floor(r() * arr.length)];
+            p.x += (r() - 0.5) * 120;
+            p.y += (r() - 0.5) * 120;
+        }
+    },
+    // One synchronized breath through the whole field.
+    'ambientHum': (pJS) => {
+        for (const p of pJS.particles.array) {
+            p.vx += Math.sin(p.seed) * 0.6;
+            p.vy += Math.cos(p.seed) * 0.6;
+        }
+    },
+    'inkSeep': (pJS, r) => {
+        const n = Math.min(6, pJS.particles.number.value_max - pJS.particles.array.length);
+        for (let i = 0; i < n; i++) {
+            const p = pJS.fn.modes.pushParticles(1, { x: r() * pJS.canvas.w, y: pJS.canvas.h + 5 })[0];
+            if (p) { p.vy = -1 - r() * 2; p.radius = 2 + r() * 3; p.fading = 250; }
+        }
+    },
+    // Geometry briefly refuses Euclid: nearby motion snaps to 45° rails.
+    'nonEuclideanShift': (pJS, r) => {
+        const arr = pJS.particles.array;
+        for (let i = 0; i < 12 && arr.length > 0; i++) {
+            const p = arr[Math.floor(r() * arr.length)];
+            const speed = Math.sqrt(p.vx * p.vx + p.vy * p.vy);
+            const snapped = Math.round(Math.atan2(p.vy, p.vx) / (Math.PI / 4)) * (Math.PI / 4);
+            p.vx = Math.cos(snapped) * speed;
+            p.vy = Math.sin(snapped) * speed;
+        }
+    },
+    'colorBleed': (pJS, r) => {
+        const arr = pJS.particles.array;
+        for (let i = 0; i < 8 && arr.length > 1; i++) {
+            const a = arr[Math.floor(r() * arr.length)];
+            const b = arr[Math.floor(r() * arr.length)];
+            if (a === b || a.colorLocked) continue;
+            a.color = { rgb: { r: (a.color.rgb.r + b.color.rgb.r) / 2, g: (a.color.rgb.g + b.color.rgb.g) / 2, b: (a.color.rgb.b + b.color.rgb.b) / 2 } };
+        }
+    },
+    // Brief glow swell; the simulation's radius decay brings them back down.
+    'bioluminescence': (pJS, r) => {
+        const arr = pJS.particles.array;
+        for (let i = 0; i < 10 && arr.length > 0; i++) {
+            const p = arr[Math.floor(r() * arr.length)];
+            p.radius = Math.min(p.radius_initial * 3, p.radius + 1.5);
+        }
+    },
 };

--- a/js/environment_sense.js
+++ b/js/environment_sense.js
@@ -1,0 +1,76 @@
+/**
+ * @file environment_sense.js
+ * @description The canvas adapts to the machine and human running it:
+ *  - prefers-reduced-motion → calm mode (warp/idle churn are clamped)
+ *  - Battery Status API → quality cap while unplugged and low
+ *  - Screen Wake Lock → the screensaver idle-cycle keeps the display awake
+ *
+ * Consumers read `reducedMotion` and `qualityCap`; background.js folds the
+ * cap into its per-frame qualityScale and asks for the wake lock when the
+ * idle auto-cycle engages.
+ */
+
+export const environmentSense = {
+    reducedMotion: false,
+    qualityCap: 1,
+    wakeLockHeld: false,
+
+    _wakeLock: null,
+    _battery: null,
+
+    init() {
+        if (typeof window.matchMedia === 'function') {
+            const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+            this.reducedMotion = mq.matches;
+            const onChange = () => { this.reducedMotion = mq.matches; };
+            if (mq.addEventListener) mq.addEventListener('change', onChange);
+        }
+
+        if (navigator.getBattery) {
+            navigator.getBattery().then((battery) => {
+                this._battery = battery;
+                const evaluate = () => {
+                    // Unplugged and below 20%: halve the budget. Below 8%: quarter it.
+                    this.qualityCap = battery.charging ? 1
+                        : battery.level < 0.08 ? 0.25
+                        : battery.level < 0.2 ? 0.5
+                        : 1;
+                };
+                battery.addEventListener('levelchange', evaluate);
+                battery.addEventListener('chargingchange', evaluate);
+                evaluate();
+            }).catch(() => { /* battery info unavailable */ });
+        }
+
+        // Re-acquire the wake lock when returning to a visible tab mid-screensaver
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible' && this.wakeLockHeld) {
+                this._wakeLock = null;
+                this.wakeLockHeld = false;
+            }
+        });
+    },
+
+    async requestWakeLock() {
+        if (this.wakeLockHeld || !('wakeLock' in navigator)) return;
+        try {
+            this._wakeLock = await navigator.wakeLock.request('screen');
+            this.wakeLockHeld = true;
+            this._wakeLock.addEventListener('release', () => {
+                this.wakeLockHeld = false;
+                this._wakeLock = null;
+            });
+        } catch (err) {
+            // Denied (e.g. low battery or hidden document) — fine, just don't hold it
+            this.wakeLockHeld = false;
+        }
+    },
+
+    releaseWakeLock() {
+        if (this._wakeLock) {
+            this._wakeLock.release().catch(() => {});
+            this._wakeLock = null;
+        }
+        this.wakeLockHeld = false;
+    },
+};

--- a/js/epoch_system.js
+++ b/js/epoch_system.js
@@ -1,0 +1,149 @@
+/**
+ * @file epoch_system.js
+ * @description Universes age. Each seed lives through four epochs over
+ * roughly twenty minutes of wall-clock time — First Light, The Long Noon,
+ * Amber Hour, The Last Ember — with the simulation slowly brightening,
+ * blooming, dimming, and finally guttering out. At heat death the universe
+ * is reborn as its own descendant: the seed gains a generation numeral
+ * (COSMIC-DRIFT-1234 → COSMIC-DRIFT-1234-II), so lineages stay shareable
+ * via the URL.
+ *
+ * Modifiers ride existing knobs (particle speed, particle cap, background
+ * hue bias and dimming) and are recaptured from scratch whenever a new
+ * universe generates, so epochs never fight blueprint or mutator setup.
+ */
+
+import { currentSeed, cataclysmInProgress } from './state.js';
+import { generateUniverse } from './universe.js';
+import { background } from './background.js';
+import { gamepadInput } from './gamepad_input.js';
+import { mulberry32, stringToSeed } from './utils.js';
+
+const EPOCHS = [
+    { name: 'First Light',   speedMul: 1.08, maxMul: 1.0,  dim: 0,    hueBias: 8 },
+    { name: 'The Long Noon', speedMul: 1.0,  maxMul: 1.0,  dim: 0,    hueBias: 0 },
+    { name: 'Amber Hour',    speedMul: 0.85, maxMul: 0.9,  dim: 0.07, hueBias: -12 },
+    { name: 'The Last Ember', speedMul: 0.62, maxMul: 0.65, dim: 0.16, hueBias: -22 },
+];
+
+const ROMAN = [[1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'], [100, 'C'], [90, 'XC'],
+    [50, 'L'], [40, 'XL'], [10, 'X'], [9, 'IX'], [5, 'V'], [4, 'IV'], [1, 'I']];
+
+export function toRoman(n) {
+    let out = '';
+    for (const [v, s] of ROMAN) {
+        while (n >= v) { out += s; n -= v; }
+    }
+    return out;
+}
+
+export function fromRoman(str) {
+    const vals = { M: 1000, D: 500, C: 100, L: 50, X: 10, V: 5, I: 1 };
+    let total = 0;
+    for (let i = 0; i < str.length; i++) {
+        const v = vals[str[i]];
+        if (!v) return NaN;
+        const next = vals[str[i + 1]] || 0;
+        total += v < next ? -v : v;
+    }
+    return total;
+}
+
+/** Split a seed into its lineage base and generation (1 = no suffix). */
+export function parseLineage(seed) {
+    const m = /^(.*)-([MDCLXVI]+)$/.exec(seed || '');
+    if (m) {
+        const gen = fromRoman(m[2]);
+        // Only canonical numerals count, so word-seeds that merely end in
+        // roman-looking letters (or junk like IIII) aren't mistaken for lineage
+        if (Number.isFinite(gen) && gen >= 2 && toRoman(gen) === m[2]) {
+            return { base: m[1], generation: gen };
+        }
+    }
+    return { base: seed || '', generation: 1 };
+}
+
+/** The next seed in a lineage: base name with an incremented numeral. */
+export function descendantSeed(seed) {
+    const { base, generation } = parseLineage(seed);
+    return `${base}-${toRoman(generation + 1)}`;
+}
+
+export const epochSystem = {
+    /** @type {{ name: string, generation: number, progress: number }} */
+    current: { name: EPOCHS[0].name, generation: 1, progress: 0 },
+    epochIndex: 0,
+
+    _seed: null,
+    _age: 0,
+    _ticksPerEpoch: 14400, // ~4 min at 60fps, re-seeded per universe
+    _baseSpeed: 1,
+    _baseMax: 400,
+    _rebirthing: false,
+
+    /** Called once per frame from the simulation loop. */
+    update(pJS) {
+        if (cataclysmInProgress) return;
+
+        if (currentSeed !== this._seed) this._adopt(pJS);
+        if (!this._seed) return;
+
+        this._age++;
+        const lifeTicks = this._ticksPerEpoch * EPOCHS.length;
+
+        if (this._age >= lifeTicks) {
+            this._rebirth(pJS);
+            return;
+        }
+
+        const idx = Math.min(EPOCHS.length - 1, Math.floor(this._age / this._ticksPerEpoch));
+        const within = (this._age - idx * this._ticksPerEpoch) / this._ticksPerEpoch;
+        this.epochIndex = idx;
+        this.current.name = EPOCHS[idx].name;
+        this.current.progress = within;
+
+        // Smoothly blend toward the next epoch's character across each epoch
+        const a = EPOCHS[idx];
+        const b = EPOCHS[Math.min(EPOCHS.length - 1, idx + 1)];
+        const t = within;
+        const speedMul = a.speedMul + (b.speedMul - a.speedMul) * t;
+        const maxMul = a.maxMul + (b.maxMul - a.maxMul) * t;
+
+        pJS.particles.move.speed = this._baseSpeed * speedMul;
+        pJS.particles.number.value_max = Math.round(this._baseMax * maxMul);
+        background.epochDim = a.dim + (b.dim - a.dim) * t;
+        background.epochHueBias = a.hueBias + (b.hueBias - a.hueBias) * t;
+    },
+
+    /** A new universe just generated: reset age and capture its baselines. */
+    _adopt(pJS) {
+        this._seed = currentSeed;
+        this._age = 0;
+        this._rebirthing = false;
+        this.epochIndex = 0;
+        const lineage = parseLineage(currentSeed);
+        this.current = { name: EPOCHS[0].name, generation: lineage.generation, progress: 0 };
+        // Per-universe lifespan: 3.5–5.5 minutes per epoch
+        const rng = mulberry32(stringToSeed(String(currentSeed) + ':epoch'));
+        this._ticksPerEpoch = 12600 + Math.floor(rng() * 7200);
+        this._baseSpeed = pJS.particles.move.speed;
+        this._baseMax = pJS.particles.number.value_max;
+        background.epochDim = 0;
+        background.epochHueBias = EPOCHS[0].hueBias;
+    },
+
+    /** Heat death: a small supernova flourish, then the descendant takes over. */
+    _rebirth(pJS) {
+        if (this._rebirthing) return;
+        this._rebirthing = true;
+        const child = descendantSeed(this._seed);
+        const cx = background.width / 2;
+        const cy = background.height / 2;
+        background.createShockwave(cx, cy);
+        background.createShockwave(cx, cy);
+        background.createShockwave(cx, cy);
+        gamepadInput.vibrate(500, 0.8, 0.8);
+        background.epochDim = 0;
+        generateUniverse(pJS, child, false);
+    },
+};

--- a/js/familiar_memory.js
+++ b/js/familiar_memory.js
@@ -1,0 +1,102 @@
+/**
+ * @file familiar_memory.js
+ * @description The cursor familiar remembers you. A localStorage-backed
+ * memory tracks how long you and your familiar have actually played together
+ * (active cursor time, not idle tabs) across visits, names the creature once
+ * on first meeting, and promotes it through growth stages:
+ *
+ *   hatchling → fledgling → companion → venerable → mythic
+ *
+ * cursor_familiar.js reads the stage to scale the creature and unlock an
+ * aura at higher stages; the HUD shows "<name> the <species> · <stage>".
+ * Everything stays on-device.
+ */
+
+const STORAGE_KEY = 'celestial-familiar-memory';
+
+// Cumulative active ticks (60/s): 0, 30 min, 2 h, 8 h, 24 h
+const STAGE_THRESHOLDS = [0, 108000, 432000, 1728000, 5184000];
+export const STAGE_NAMES = ['hatchling', 'fledgling', 'companion', 'venerable', 'mythic'];
+
+const SYLLABLES = ['ka', 've', 'sk', 'lu', 'mi', 'ra', 'no', 'th', 'el', 'ir',
+    'os', 'ya', 'zu', 'fen', 'qui', 'br', 'um', 'ash', 'ol', 'wyn'];
+
+function generateName(seedNum) {
+    let lcg = (seedNum >>> 0) || 1;
+    const next = () => {
+        lcg = (Math.imul(lcg, 1664525) + 1013904223) >>> 0;
+        return lcg / 4294967296;
+    };
+    const count = 2 + (next() < 0.35 ? 1 : 0);
+    let name = '';
+    for (let i = 0; i < count; i++) name += SYLLABLES[Math.floor(next() * SYLLABLES.length)];
+    return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+export const familiarMemory = {
+    loaded: false,
+    name: '',
+    visits: 0,
+    totalActiveTicks: 0,
+
+    _dirty: 0,
+
+    init() {
+        let data = null;
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) data = JSON.parse(raw);
+        } catch (err) {
+            // Storage unavailable (private mode, etc.) — run as a one-visit memory
+        }
+        if (data && typeof data === 'object') {
+            this.name = typeof data.name === 'string' ? data.name : '';
+            this.visits = Number.isFinite(data.visits) ? data.visits : 0;
+            this.totalActiveTicks = Number.isFinite(data.totalActiveTicks) ? data.totalActiveTicks : 0;
+        }
+        if (!this.name) this.name = generateName(Date.now());
+        this.visits++;
+        this.loaded = true;
+        this._save();
+
+        // Persist on tab hide so progress survives abrupt closes
+        if (typeof document !== 'undefined' && document.addEventListener) {
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'hidden') this._save();
+            });
+        }
+    },
+
+    /** Count one tick of genuine play (cursor moving near the familiar). */
+    recordActivity() {
+        if (!this.loaded) return;
+        this.totalActiveTicks++;
+        if (++this._dirty >= 600) this._save(); // every ~10s of activity
+    },
+
+    /** Growth stage index 0..4 from cumulative play time. */
+    get stage() {
+        let s = 0;
+        for (let i = 0; i < STAGE_THRESHOLDS.length; i++) {
+            if (this.totalActiveTicks >= STAGE_THRESHOLDS[i]) s = i;
+        }
+        return s;
+    },
+
+    get stageName() {
+        return STAGE_NAMES[this.stage];
+    },
+
+    _save() {
+        this._dirty = 0;
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({
+                name: this.name,
+                visits: this.visits,
+                totalActiveTicks: this.totalActiveTicks,
+            }));
+        } catch (err) {
+            // Best effort only
+        }
+    },
+};

--- a/js/familiar_species.js
+++ b/js/familiar_species.js
@@ -54,6 +54,7 @@ function followChain(segs, headX, headY, spacing, stiffness) {
 
 const wisp = {
     name: 'wisp',
+    label: 'wisp',
     init(f, rng) {
         f.aux = { flamePhase: rng() * TAU, emberClock: 0 };
     },
@@ -105,6 +106,7 @@ const wisp = {
 
 const mothFlock = {
     name: 'mothFlock',
+    label: 'moth flock',
     init(f, rng) {
         const moths = [];
         const count = 3 + Math.floor(rng() * 4);
@@ -178,6 +180,7 @@ const mothFlock = {
 
 const serpent = {
     name: 'serpent',
+    label: 'serpent',
     init(f, rng) {
         const n = 14 + Math.floor(rng() * 9);
         const segs = [];
@@ -261,6 +264,7 @@ const serpent = {
 
 const satellites = {
     name: 'satellites',
+    label: 'satellite swarm',
     init(f, rng) {
         const shards = [];
         const count = 3 + Math.floor(rng() * 3);
@@ -334,6 +338,7 @@ const satellites = {
 
 const jelly = {
     name: 'jelly',
+    label: 'jelly',
     init(f, rng) {
         const verts = [];
         const n = 10;
@@ -426,6 +431,7 @@ const jelly = {
 
 const oculus = {
     name: 'oculus',
+    label: 'oculus',
     init(f, rng) {
         f.aux = {
             blinkAt: 200 + Math.floor(rng() * 240),

--- a/js/familiar_species.js
+++ b/js/familiar_species.js
@@ -1,0 +1,529 @@
+/**
+ * @file familiar_species.js
+ * @description Species library for the cursor familiar — a small creature that
+ * lives at your cursor and behaves like a pet: it follows with its own
+ * locomotion, dozes off when you go idle, and startles when you click.
+ *
+ * Each species defines:
+ *  - init(f, rng):   build species-specific anatomy into f.aux
+ *  - update(f):      advance locomotion/animation (f.x/f.y already steered)
+ *  - draw(ctx, f):   render the creature
+ *
+ * All species read the shared familiar state:
+ *  f.x, f.y           - body position (spring-follows the cursor)
+ *  f.vx, f.vy         - body velocity
+ *  f.heading          - smoothed travel direction (radians)
+ *  f.speed            - smoothed travel speed (px/frame)
+ *  f.excitement       - 0..1 smoothed cursor activity
+ *  f.mode             - 'follow' | 'doze' | 'startle'
+ *  f.startleT         - 1..0 during a startle, else 0
+ *  f.dozeT            - 0..1 ease into doze
+ *  f.size             - base scale (seeded)
+ *  f.hue, f.hue2      - palette hues
+ *  f.tick             - frame counter
+ *  f.rand()           - deterministic runtime RNG
+ *  f.emit(style, x, y, vx, vy, life, size)  - pooled trail particle
+ */
+
+const TAU = Math.PI * 2;
+
+function lerpAngle(a, b, t) {
+    let d = (b - a) % TAU;
+    if (d > Math.PI) d -= TAU;
+    if (d < -Math.PI) d += TAU;
+    return a + d * t;
+}
+
+/** Advance a rope of points so each link trails the previous at fixed spacing. */
+function followChain(segs, headX, headY, spacing, stiffness) {
+    segs[0].x = headX;
+    segs[0].y = headY;
+    for (let i = 1; i < segs.length; i++) {
+        const prev = segs[i - 1];
+        const s = segs[i];
+        const dx = prev.x - s.x;
+        const dy = prev.y - s.y;
+        const d = Math.hypot(dx, dy) || 1;
+        const pull = (d - spacing) * stiffness;
+        s.x += (dx / d) * pull;
+        s.y += (dy / d) * pull;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────── wisp ──
+
+const wisp = {
+    name: 'wisp',
+    init(f, rng) {
+        f.aux = { flamePhase: rng() * TAU, emberClock: 0 };
+    },
+    update(f) {
+        const a = f.aux;
+        // Embers stream while moving, sputter while dozing
+        a.emberClock++;
+        const interval = f.mode === 'doze' ? 26 : Math.max(2, (7 - f.speed) | 0);
+        if (a.emberClock >= interval) {
+            a.emberClock = 0;
+            const r = f.rand;
+            f.emit('ember', f.x + (r() - 0.5) * 6, f.y + (r() - 0.5) * 6,
+                (r() - 0.5) * 0.6 - f.vx * 0.15, -0.4 - r() * 0.8, 34 + r() * 22, 1 + r() * 2);
+        }
+        if (f.startleT > 0.92 && f.startleT < 0.98) {
+            // One-shot flare burst at the start of a startle
+            for (let i = 0; i < 12; i++) {
+                const ang = (i / 12) * TAU;
+                f.emit('ember', f.x, f.y, Math.cos(ang) * 2.4, Math.sin(ang) * 2.4, 26, 1.6);
+            }
+        }
+    },
+    draw(ctx, f) {
+        const flick = 1 + Math.sin(f.tick * 0.31 + f.aux.flamePhase) * (0.1 + f.excitement * 0.15);
+        const s = f.size * (1 - f.dozeT * 0.55) * flick * (1 + f.startleT * 0.8);
+        const ang = f.speed > 0.4 ? f.heading + Math.PI : -Math.PI / 2; // tail away from motion, else up
+        const tx = Math.cos(ang);
+        const ty = Math.sin(ang);
+        const tailLen = s * (2.2 + f.speed * 0.25);
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        // Outer teardrop
+        ctx.fillStyle = `hsla(${f.hue}, 90%, 60%, ${0.5 - f.dozeT * 0.2})`;
+        ctx.beginPath();
+        ctx.moveTo(f.x + tx * tailLen, f.y + ty * tailLen);
+        ctx.quadraticCurveTo(f.x - ty * s, f.y + tx * s, f.x - tx * s * 0.8, f.y - ty * s * 0.8);
+        ctx.quadraticCurveTo(f.x + ty * s, f.y - tx * s, f.x + tx * tailLen, f.y + ty * tailLen);
+        ctx.fill();
+        // Hot core
+        ctx.fillStyle = `hsla(${f.hue2}, 100%, 82%, ${0.8 - f.dozeT * 0.3})`;
+        ctx.beginPath();
+        ctx.arc(f.x - tx * s * 0.25, f.y - ty * s * 0.25, s * 0.42, 0, TAU);
+        ctx.fill();
+        ctx.restore();
+    },
+};
+
+// ──────────────────────────────────────────────────────────── mothFlock ──
+
+const mothFlock = {
+    name: 'mothFlock',
+    init(f, rng) {
+        const moths = [];
+        const count = 3 + Math.floor(rng() * 4);
+        for (let i = 0; i < count; i++) {
+            moths.push({
+                phase: rng() * TAU,
+                radius: 16 + rng() * 26,
+                speed: (0.02 + rng() * 0.03) * (rng() < 0.5 ? 1 : -1),
+                size: f.size * (0.45 + rng() * 0.4),
+                hueOff: (rng() - 0.5) * 50,
+                wingPhase: rng() * TAU,
+                bob: rng() * TAU,
+                x: 0, y: 0, scatter: 0,
+            });
+        }
+        f.aux = { moths };
+    },
+    update(f) {
+        for (const m of f.aux.moths) {
+            m.phase += m.speed * (1 + f.excitement * 1.6) * (1 - f.dozeT * 0.85);
+            if (f.startleT > 0.92 && f.startleT < 0.98) m.scatter = 1;
+            m.scatter *= 0.94;
+            const r = m.radius * (1 - f.dozeT * 0.6) * (1 + m.scatter * 2.4);
+            const bobY = Math.sin(f.tick * 0.05 + m.bob) * 4 * (1 - f.dozeT);
+            m.x = f.x + Math.cos(m.phase) * r;
+            m.y = f.y + Math.sin(m.phase) * r * 0.62 + bobY;
+            if (f.rand() < 0.02 * f.excitement) {
+                f.emit('petal', m.x, m.y, (f.rand() - 0.5) * 0.4, 0.2 + f.rand() * 0.3, 40, 1.2);
+            }
+        }
+    },
+    draw(ctx, f) {
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        for (const m of f.aux.moths) {
+            const wingRate = 0.08 + (0.3 + f.excitement * 0.4) * (1 - f.dozeT * 0.92);
+            const flap = Math.sin(f.tick * wingRate * TAU * 0.16 + m.wingPhase) * (1 - f.dozeT * 0.7);
+            const hue = (f.hue + m.hueOff + 360) % 360;
+            const s = m.size;
+            const dir = m.phase + (m.speed > 0 ? Math.PI / 2 : -Math.PI / 2);
+            ctx.save();
+            ctx.translate(m.x, m.y);
+            ctx.rotate(dir);
+            // Wings: two triangles folding around the body axis
+            const spread = 0.55 + flap * 0.5;
+            ctx.fillStyle = `hsla(${hue}, 75%, 70%, ${0.55 - f.dozeT * 0.25})`;
+            ctx.beginPath();
+            ctx.moveTo(0, 0);
+            ctx.lineTo(-s * 2.1, -s * 2.6 * spread);
+            ctx.lineTo(s * 0.4, -s * 0.5);
+            ctx.closePath();
+            ctx.fill();
+            ctx.beginPath();
+            ctx.moveTo(0, 0);
+            ctx.lineTo(-s * 2.1, s * 2.6 * spread);
+            ctx.lineTo(s * 0.4, s * 0.5);
+            ctx.closePath();
+            ctx.fill();
+            // Body + glow dot
+            ctx.fillStyle = `hsla(${f.hue2}, 90%, 85%, 0.9)`;
+            ctx.beginPath();
+            ctx.ellipse(0, 0, s * 0.9, s * 0.34, 0, 0, TAU);
+            ctx.fill();
+            ctx.restore();
+        }
+        ctx.restore();
+    },
+};
+
+// ────────────────────────────────────────────────────────────── serpent ──
+
+const serpent = {
+    name: 'serpent',
+    init(f, rng) {
+        const n = 14 + Math.floor(rng() * 9);
+        const segs = [];
+        for (let i = 0; i < n; i++) segs.push({ x: f.x - i * 6, y: f.y });
+        f.aux = { segs, spacing: 5 + rng() * 3, coilDir: rng() < 0.5 ? 1 : -1, shiver: 0 };
+    },
+    update(f) {
+        const a = f.aux;
+        if (f.startleT > 0.92 && f.startleT < 0.98) a.shiver = 1;
+        a.shiver *= 0.9;
+        // Head seeks a point: the familiar body, or a slow coil orbit while dozing
+        let hx = f.x;
+        let hy = f.y;
+        if (f.dozeT > 0.3) {
+            const coilAng = f.tick * 0.012 * a.coilDir;
+            const coilR = 16 + 10 * (1 - f.dozeT);
+            hx = f.x + Math.cos(coilAng) * coilR;
+            hy = f.y + Math.sin(coilAng) * coilR * 0.8;
+        } else {
+            // Slither: weave perpendicular to travel
+            const weave = Math.sin(f.tick * (0.12 + f.excitement * 0.12)) * (4 + f.speed * 1.6);
+            hx += Math.cos(f.heading + Math.PI / 2) * weave;
+            hy += Math.sin(f.heading + Math.PI / 2) * weave;
+        }
+        followChain(a.segs, hx, hy, a.spacing, 0.55);
+        if (a.shiver > 0.05) {
+            for (let i = 2; i < a.segs.length; i += 2) {
+                const side = i % 4 === 0 ? 1 : -1;
+                a.segs[i].x += Math.cos(f.heading + Math.PI / 2) * side * a.shiver * 5;
+                a.segs[i].y += Math.sin(f.heading + Math.PI / 2) * side * a.shiver * 5;
+            }
+        }
+        if (f.speed > 2 && f.tick % 5 === 0) {
+            const tail = a.segs[a.segs.length - 1];
+            f.emit('spark', tail.x, tail.y, 0, 0, 24, 1);
+        }
+    },
+    draw(ctx, f) {
+        const segs = f.aux.segs;
+        const n = segs.length;
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+        // Tapered body in 3 width bands (cheap taper without per-segment strokes)
+        const bands = [
+            { from: 0, to: n * 0.34 | 0, w: f.size * 0.85, l: 66 },
+            { from: n * 0.34 | 0, to: n * 0.7 | 0, w: f.size * 0.55, l: 58 },
+            { from: n * 0.7 | 0, to: n - 1, w: f.size * 0.26, l: 50 },
+        ];
+        for (const b of bands) {
+            if (b.to <= b.from) continue;
+            ctx.strokeStyle = `hsla(${f.hue}, 80%, ${b.l}%, ${0.65 - f.dozeT * 0.25})`;
+            ctx.lineWidth = Math.max(0.8, b.w * (1 - f.dozeT * 0.25));
+            ctx.beginPath();
+            ctx.moveTo(segs[b.from].x, segs[b.from].y);
+            for (let i = b.from + 1; i <= b.to; i++) ctx.lineTo(segs[i].x, segs[i].y);
+            ctx.stroke();
+        }
+        // Head: skull dot + eyes
+        const head = segs[0];
+        const neck = segs[1];
+        const hAng = Math.atan2(head.y - neck.y, head.x - neck.x);
+        ctx.fillStyle = `hsla(${f.hue}, 85%, 72%, 0.9)`;
+        ctx.beginPath();
+        ctx.arc(head.x, head.y, f.size * 0.62, 0, TAU);
+        ctx.fill();
+        const blink = f.dozeT > 0.5 ? 0.3 : 1;
+        ctx.fillStyle = `hsla(${f.hue2}, 100%, 88%, ${0.95 * blink})`;
+        for (const side of [-1, 1]) {
+            ctx.beginPath();
+            ctx.arc(head.x + Math.cos(hAng + side * 0.8) * f.size * 0.4,
+                head.y + Math.sin(hAng + side * 0.8) * f.size * 0.4, f.size * 0.14, 0, TAU);
+            ctx.fill();
+        }
+        ctx.restore();
+    },
+};
+
+// ─────────────────────────────────────────────────────────── satellites ──
+
+const satellites = {
+    name: 'satellites',
+    init(f, rng) {
+        const shards = [];
+        const count = 3 + Math.floor(rng() * 3);
+        for (let i = 0; i < count; i++) {
+            shards.push({
+                shell: i % 2,
+                angle: rng() * TAU,
+                angVel: (0.015 + rng() * 0.02) * (i % 2 === 0 ? 1 : -1),
+                size: f.size * (0.3 + rng() * 0.35),
+                sides: 3 + Math.floor(rng() * 3),
+                spin: rng() * TAU,
+                spinVel: (rng() - 0.5) * 0.1,
+                flash: 0,
+                x: 0, y: 0,
+            });
+        }
+        f.aux = { shards, shellR: [20 + rng() * 8, 40 + rng() * 14] };
+    },
+    update(f) {
+        const a = f.aux;
+        const swap = f.startleT > 0.92 && f.startleT < 0.98;
+        for (const sh of a.shards) {
+            if (swap) {
+                sh.shell = 1 - sh.shell;
+                sh.flash = 1;
+            }
+            sh.flash *= 0.92;
+            sh.angle += sh.angVel * (1 + f.excitement * 2);
+            sh.spin += sh.spinVel;
+            const targetR = f.dozeT > 0.3 ? 10 : a.shellR[sh.shell];
+            if (sh.r === undefined) sh.r = targetR;
+            sh.r += (targetR - sh.r) * 0.08;
+            sh.x = f.x + Math.cos(sh.angle) * sh.r;
+            sh.y = f.y + Math.sin(sh.angle) * sh.r;
+        }
+    },
+    draw(ctx, f) {
+        const a = f.aux;
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        // Hub
+        ctx.fillStyle = `hsla(${f.hue2}, 90%, 80%, ${0.7 - f.dozeT * 0.3})`;
+        ctx.beginPath();
+        ctx.arc(f.x, f.y, 2.2, 0, TAU);
+        ctx.fill();
+        ctx.lineWidth = 1;
+        for (const sh of a.shards) {
+            // Tether
+            ctx.strokeStyle = `hsla(${f.hue}, 70%, 65%, ${0.1 + sh.flash * 0.4})`;
+            ctx.beginPath();
+            ctx.moveTo(f.x, f.y);
+            ctx.lineTo(sh.x, sh.y);
+            ctx.stroke();
+            // Polygon shard
+            ctx.strokeStyle = `hsla(${f.hue}, 85%, ${62 + sh.flash * 30}%, ${0.8 - f.dozeT * 0.35})`;
+            ctx.beginPath();
+            for (let i = 0; i <= sh.sides; i++) {
+                const ang = sh.spin + (i / sh.sides) * TAU;
+                const px = sh.x + Math.cos(ang) * sh.size;
+                const py = sh.y + Math.sin(ang) * sh.size;
+                if (i === 0) ctx.moveTo(px, py);
+                else ctx.lineTo(px, py);
+            }
+            ctx.stroke();
+        }
+        ctx.restore();
+    },
+};
+
+// ──────────────────────────────────────────────────────────────── jelly ──
+
+const jelly = {
+    name: 'jelly',
+    init(f, rng) {
+        const verts = [];
+        const n = 10;
+        for (let i = 0; i < n; i++) verts.push({ off: 0, vel: 0 });
+        const tendrils = [];
+        const tCount = 4 + Math.floor(rng() * 3);
+        for (let t = 0; t < tCount; t++) {
+            const chain = [];
+            for (let i = 0; i < 5; i++) chain.push({ x: f.x, y: f.y });
+            tendrils.push({ chain, frac: t / tCount });
+        }
+        f.aux = { verts, tendrils, pulse: rng() * TAU, inked: false };
+    },
+    update(f) {
+        const a = f.aux;
+        const pop = f.startleT > 0.92 && f.startleT < 0.98;
+        for (const v of a.verts) {
+            if (pop) v.vel += 2.5;
+            v.vel += -v.off * 0.18 - v.vel * 0.22; // spring to rest
+            v.off += v.vel;
+        }
+        if (pop && !a.inked) {
+            a.inked = true;
+            for (let i = 0; i < 6; i++) {
+                f.emit('ink', f.x, f.y, (f.rand() - 0.5) * 2, (f.rand() - 0.5) * 2, 50, 3 + f.rand() * 3);
+            }
+        }
+        if (f.startleT === 0) a.inked = false;
+        const r = f.size * 1.5;
+        for (const t of a.tendrils) {
+            const ang = t.frac * TAU + Math.PI / 2 - 0.6 + t.frac * 1.2; // hang below
+            const ax = f.x + Math.cos(ang) * r * 0.5;
+            const ay = f.y + Math.abs(Math.sin(ang)) * r * 0.5;
+            followChain(t.chain, ax, ay, 4 + f.size * 0.3, 0.4);
+            // Gravity sag on tendrils
+            for (let i = 1; i < t.chain.length; i++) t.chain[i].y += 0.5;
+        }
+    },
+    draw(ctx, f) {
+        const a = f.aux;
+        const breath = Math.sin(f.tick * (0.05 - f.dozeT * 0.025) + a.pulse) * 0.12;
+        const r = f.size * 1.5 * (1 + breath) * (1 - f.dozeT * 0.2);
+        const squashX = 1 + Math.min(0.4, Math.abs(f.vx) * 0.03);
+        const squashY = 1 + Math.min(0.4, Math.abs(f.vy) * 0.03);
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.lineWidth = 1.2;
+        for (const t of a.tendrils) {
+            ctx.strokeStyle = `hsla(${f.hue}, 70%, 70%, ${0.35 - f.dozeT * 0.15})`;
+            ctx.beginPath();
+            ctx.moveTo(t.chain[0].x, t.chain[0].y);
+            for (let i = 1; i < t.chain.length; i++) ctx.lineTo(t.chain[i].x, t.chain[i].y);
+            ctx.stroke();
+        }
+        ctx.translate(f.x, f.y);
+        ctx.scale(squashX, Math.max(0.6, 2 - squashY));
+        const n = a.verts.length;
+        ctx.fillStyle = `hsla(${f.hue}, 75%, 62%, ${0.3 - f.dozeT * 0.1})`;
+        ctx.strokeStyle = `hsla(${f.hue2}, 90%, 78%, ${0.7 - f.dozeT * 0.3})`;
+        ctx.beginPath();
+        for (let i = 0; i <= n; i++) {
+            const i0 = i % n;
+            const i1 = (i + 1) % n;
+            const a0 = (i0 / n) * TAU;
+            const a1 = (i1 / n) * TAU;
+            const r0 = r + a.verts[i0].off;
+            const r1 = r + a.verts[i1].off;
+            const x0 = Math.cos(a0) * r0;
+            const y0 = Math.sin(a0) * r0;
+            const x1 = Math.cos(a1) * r1;
+            const y1 = Math.sin(a1) * r1;
+            if (i === 0) ctx.moveTo((x0 + x1) / 2, (y0 + y1) / 2);
+            else ctx.quadraticCurveTo(x0, y0, (x0 + x1) / 2, (y0 + y1) / 2);
+        }
+        ctx.fill();
+        ctx.stroke();
+        // Eyes (closed while dozing)
+        if (f.dozeT < 0.5) {
+            ctx.fillStyle = `hsla(${f.hue2}, 95%, 90%, 0.9)`;
+            ctx.beginPath();
+            ctx.arc(-r * 0.3, -r * 0.1, 1.6, 0, TAU);
+            ctx.arc(r * 0.3, -r * 0.1, 1.6, 0, TAU);
+            ctx.fill();
+        }
+        ctx.restore();
+    },
+};
+
+// ─────────────────────────────────────────────────────────────── oculus ──
+
+const oculus = {
+    name: 'oculus',
+    init(f, rng) {
+        f.aux = {
+            blinkAt: 200 + Math.floor(rng() * 240),
+            blinkClock: 0,
+            lid: 1, // 1 = open
+            wanderAng: rng() * TAU,
+        };
+    },
+    update(f) {
+        const a = f.aux;
+        a.blinkClock++;
+        if (a.blinkClock >= a.blinkAt) {
+            a.blinkClock = 0;
+            a.blinkAt = 160 + Math.floor(f.rand() * 300);
+        }
+        // Lid: brief close at the start of each blink cycle; droop while dozing
+        const blinkPhase = a.blinkClock < 16 ? Math.abs(8 - a.blinkClock) / 8 : 1;
+        const target = Math.min(blinkPhase, 1 - f.dozeT * 0.62) + f.startleT * 0.6;
+        a.lid += (Math.min(1, target) - a.lid) * 0.3;
+        if (f.dozeT > 0.3) a.wanderAng += (f.rand() - 0.5) * 0.1;
+        if (f.startleT > 0.92 && f.startleT < 0.98) {
+            f.emit('ring', f.x, f.y, 0, 0, 30, f.size * 1.6);
+        }
+    },
+    draw(ctx, f) {
+        const a = f.aux;
+        const r = f.size * 1.6;
+        const lid = Math.max(0.06, a.lid);
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.translate(f.x, f.y);
+        // Almond outline via two mirrored quadratic lids
+        ctx.fillStyle = `hsla(${f.hue}, 35%, 16%, 0.85)`;
+        ctx.strokeStyle = `hsla(${f.hue}, 80%, 65%, 0.8)`;
+        ctx.lineWidth = 1.4;
+        ctx.beginPath();
+        ctx.moveTo(-r, 0);
+        ctx.quadraticCurveTo(0, -r * 1.15 * lid, r, 0);
+        ctx.quadraticCurveTo(0, r * 1.15 * lid, -r, 0);
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+        // Iris + pupil track the cursor's motion; wander while dozing
+        ctx.save();
+        ctx.clip();
+        let lookX;
+        let lookY;
+        if (f.dozeT > 0.3) {
+            lookX = Math.cos(a.wanderAng) * r * 0.25;
+            lookY = Math.sin(a.wanderAng) * r * 0.12;
+        } else {
+            const sp = Math.max(0.001, f.speed);
+            lookX = (f.vx / (sp + 2)) * r * 0.4;
+            lookY = (f.vy / (sp + 2)) * r * 0.25;
+        }
+        const irisR = r * 0.52 * (1 - f.startleT * 0.25);
+        ctx.fillStyle = `hsla(${f.hue2}, 85%, 55%, 0.95)`;
+        ctx.beginPath();
+        ctx.arc(lookX, lookY, irisR, 0, TAU);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(4, 4, 10, 0.95)';
+        ctx.beginPath();
+        ctx.arc(lookX, lookY, irisR * (0.42 + f.startleT * 0.3), 0, TAU);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
+        ctx.beginPath();
+        ctx.arc(lookX - irisR * 0.3, lookY - irisR * 0.3, irisR * 0.14, 0, TAU);
+        ctx.fill();
+        ctx.restore();
+        ctx.restore();
+    },
+};
+
+export const FAMILIAR_SPECIES = [wisp, mothFlock, serpent, satellites, jelly, oculus];
+
+/**
+ * Blueprint-affinity weights: which species feel native to which universes.
+ * Index order matches FAMILIAR_SPECIES.
+ */
+const SPECIES_AFFINITY = {
+    wisp: ['StarForged', 'CelestialForge', 'MoltenHeart', 'VolcanicForge', 'StellarNursery', 'Classical'],
+    mothFlock: ['Organic', 'FungalForest', 'SilkWeaver', 'Papercraft', 'Painterly', 'CoralReef'],
+    serpent: ['BioMechanical', 'SentientSwarm', 'GooeyMess', 'LivingInk', 'AbyssalZone', 'ChronoVerse'],
+    satellites: ['Digital', 'TechnoUtopia', 'NeonCyber', 'QuantumFoam', 'ArcaneCodex', 'Crystalline'],
+    jelly: ['GlassySea', 'CoralReef', 'AbyssalZone', 'Aetherial', 'GooeyMess', 'GlacialDrift'],
+    oculus: ['Eldritch', 'VoidTouched', 'AbyssalHorror', 'HauntedRealm', 'PhantomEcho', 'ArcaneCodex'],
+};
+
+/** Pick a species for this universe: 3x weight when the blueprint matches. */
+export function selectSpecies(rng, blueprintName) {
+    const weights = FAMILIAR_SPECIES.map(sp =>
+        (SPECIES_AFFINITY[sp.name] || []).includes(blueprintName) ? 3 : 1);
+    let total = 0;
+    for (const w of weights) total += w;
+    let roll = rng() * total;
+    for (let i = 0; i < weights.length; i++) {
+        roll -= weights[i];
+        if (roll <= 0) return FAMILIAR_SPECIES[i];
+    }
+    return FAMILIAR_SPECIES[0];
+}

--- a/js/help_overlay.js
+++ b/js/help_overlay.js
@@ -14,6 +14,8 @@ const SHORTCUTS = [
     { key: 'B',              desc: 'Toggle architecture blending' },
     { key: 'F',              desc: 'Open favorites' },
     { key: 'T',              desc: 'Open theme editor' },
+    { key: 'R',              desc: 'Record a WebM clip (30s max)' },
+    { key: '\ud83c\udfb9',   desc: 'Toolbar: MIDI knobs warp, notes strike' },
     { key: '\u2190 \u2192',  desc: 'Cycle architecture' },
     { key: 'Click',          desc: 'Shockwave' },
     { key: 'Right-click',    desc: 'Gravity well' },

--- a/js/help_overlay.js
+++ b/js/help_overlay.js
@@ -16,6 +16,7 @@ const SHORTCUTS = [
     { key: 'T',              desc: 'Open theme editor' },
     { key: 'R',              desc: 'Record a WebM clip (30s max)' },
     { key: 'O',              desc: 'Save a captioned postcard PNG' },
+    { key: 'J',              desc: 'Open the constellation journal' },
     { key: '\ud83c\udfb9',   desc: 'Toolbar: MIDI knobs warp, notes strike' },
     { key: '\u2190 \u2192',  desc: 'Cycle architecture' },
     { key: 'Click',          desc: 'Shockwave' },

--- a/js/help_overlay.js
+++ b/js/help_overlay.js
@@ -15,6 +15,7 @@ const SHORTCUTS = [
     { key: 'F',              desc: 'Open favorites' },
     { key: 'T',              desc: 'Open theme editor' },
     { key: 'R',              desc: 'Record a WebM clip (30s max)' },
+    { key: 'O',              desc: 'Save a captioned postcard PNG' },
     { key: '\ud83c\udfb9',   desc: 'Toolbar: MIDI knobs warp, notes strike' },
     { key: '\u2190 \u2192',  desc: 'Cycle architecture' },
     { key: 'Click',          desc: 'Shockwave' },

--- a/js/hud.js
+++ b/js/hud.js
@@ -4,6 +4,7 @@
  */
 
 import { universeProfile, currentSeed } from './state.js';
+import { loreCodex } from './lore_codex.js';
 import { gamepadInput } from './gamepad_input.js';
 import { micReactive } from './mic_reactive.js';
 import { tabSync } from './tab_sync.js';
@@ -16,6 +17,7 @@ import { background, ARCH_DISPLAY_NAMES } from './background.js';
 
 export const hud = (() => {
     let container, blueprintEl, descriptionEl, seedEl, mutatorEl, anomalyEl, fpsEl;
+    let epithetEl, loreEl, _lastLore = null;
     let badgeGamepad, badgeMic, badgeCamera, badgeSpeech, badgeTab;
 
     let lastMouseTime = 0;
@@ -45,6 +47,12 @@ export const hud = (() => {
 
         descriptionEl = document.createElement('div');
         descriptionEl.style.cssText = 'font-size:10px;color:rgba(255,255,255,0.35);font-style:italic;font-family:"Exo 2",sans-serif;margin-top:2px;';
+
+        // Procedural field-guide lore (lore_codex.js)
+        epithetEl = document.createElement('div');
+        epithetEl.style.cssText = 'font-size:11px;color:rgba(255,255,255,0.55);font-family:"Exo 2",sans-serif;margin-top:4px;letter-spacing:0.5px;';
+        loreEl = document.createElement('div');
+        loreEl.style.cssText = 'font-size:10px;color:rgba(255,255,255,0.3);font-style:italic;font-family:"Exo 2",sans-serif;margin-top:1px;max-width:300px;line-height:1.4;';
 
         seedEl = document.createElement('span');
         seedEl.id = 'seed-capture';
@@ -98,6 +106,8 @@ export const hud = (() => {
 
         container.appendChild(blueprintEl);
         container.appendChild(descriptionEl);
+        container.appendChild(epithetEl);
+        container.appendChild(loreEl);
         container.appendChild(seedEl);
         container.appendChild(mutatorEl);
         container.appendChild(anomalyEl);
@@ -157,6 +167,13 @@ export const hud = (() => {
         // Seed
         if (document.activeElement !== seedEl && !seedEl.classList.contains('copied-animation')) {
             seedEl.textContent = currentSeed || '';
+        }
+
+        // Field-guide lore (only touch the DOM when a new universe is logged)
+        if (loreCodex.current !== _lastLore) {
+            _lastLore = loreCodex.current;
+            epithetEl.textContent = _lastLore ? _lastLore.epithet : '';
+            loreEl.textContent = _lastLore ? _lastLore.note : '';
         }
 
         // Mutators

--- a/js/hud.js
+++ b/js/hud.js
@@ -5,6 +5,9 @@
 
 import { universeProfile, currentSeed } from './state.js';
 import { loreCodex } from './lore_codex.js';
+import { epochSystem, toRoman } from './epoch_system.js';
+import { familiarMemory } from './familiar_memory.js';
+import { cursorFamiliar } from './cursor_familiar.js';
 import { gamepadInput } from './gamepad_input.js';
 import { micReactive } from './mic_reactive.js';
 import { tabSync } from './tab_sync.js';
@@ -18,6 +21,7 @@ import { background, ARCH_DISPLAY_NAMES } from './background.js';
 export const hud = (() => {
     let container, blueprintEl, descriptionEl, seedEl, mutatorEl, anomalyEl, fpsEl;
     let epithetEl, loreEl, _lastLore = null;
+    let epochEl, familiarEl, _lastEpochText = '', _lastFamiliarText = '';
     let badgeGamepad, badgeMic, badgeCamera, badgeSpeech, badgeTab;
 
     let lastMouseTime = 0;
@@ -53,6 +57,12 @@ export const hud = (() => {
         epithetEl.style.cssText = 'font-size:11px;color:rgba(255,255,255,0.55);font-family:"Exo 2",sans-serif;margin-top:4px;letter-spacing:0.5px;';
         loreEl = document.createElement('div');
         loreEl.style.cssText = 'font-size:10px;color:rgba(255,255,255,0.3);font-style:italic;font-family:"Exo 2",sans-serif;margin-top:1px;max-width:300px;line-height:1.4;';
+
+        // Universe age (epoch_system.js) and your familiar (familiar_memory.js)
+        epochEl = document.createElement('div');
+        epochEl.style.cssText = 'font-size:10px;color:rgba(255,220,170,0.45);font-family:"Exo 2",sans-serif;margin-top:3px;letter-spacing:0.5px;';
+        familiarEl = document.createElement('div');
+        familiarEl.style.cssText = 'font-size:10px;color:rgba(180,220,255,0.45);font-family:"Exo 2",sans-serif;margin-top:1px;letter-spacing:0.5px;';
 
         seedEl = document.createElement('span');
         seedEl.id = 'seed-capture';
@@ -108,6 +118,8 @@ export const hud = (() => {
         container.appendChild(descriptionEl);
         container.appendChild(epithetEl);
         container.appendChild(loreEl);
+        container.appendChild(epochEl);
+        container.appendChild(familiarEl);
         container.appendChild(seedEl);
         container.appendChild(mutatorEl);
         container.appendChild(anomalyEl);
@@ -174,6 +186,23 @@ export const hud = (() => {
             _lastLore = loreCodex.current;
             epithetEl.textContent = _lastLore ? _lastLore.epithet : '';
             loreEl.textContent = _lastLore ? _lastLore.note : '';
+        }
+
+        // Epoch + lineage, e.g. "Amber Hour · Gen III"
+        const gen = epochSystem.current.generation;
+        const epochText = epochSystem.current.name + (gen > 1 ? ` · Gen ${toRoman(gen)}` : '');
+        if (epochText !== _lastEpochText) {
+            _lastEpochText = epochText;
+            epochEl.textContent = epochText;
+        }
+
+        // Your familiar, e.g. "Veska the serpent · companion"
+        const famText = familiarMemory.loaded
+            ? `${familiarMemory.name} the ${cursorFamiliar.species.label || cursorFamiliar.species.name} · ${familiarMemory.stageName}`
+            : '';
+        if (famText !== _lastFamiliarText) {
+            _lastFamiliarText = famText;
+            familiarEl.textContent = famText;
         }
 
         // Mutators

--- a/js/input_toolbar.js
+++ b/js/input_toolbar.js
@@ -7,8 +7,10 @@
 import { micReactive } from './mic_reactive.js';
 import { cameraInput } from './camera_input.js';
 import { speechInput } from './speech_input.js';
+import { midiInput } from './midi_input.js';
+import { videoExport } from './video_export.js';
 
-const ACCENTS = { mic: '#4fc3f7', camera: '#ef5350', speech: '#ab47bc' };
+const ACCENTS = { mic: '#4fc3f7', camera: '#ef5350', speech: '#ab47bc', midi: '#ffd54f', record: '#ff5252' };
 
 let _toolbar = null;
 let _buttons = {};
@@ -148,6 +150,34 @@ export const inputToolbar = {
             _buttons.speech = btn;
         }
 
+        if (midiInput.supported) {
+            const btn = _makeButton('🎹', ACCENTS.midi);
+            btn.title = 'Connect a MIDI controller: knobs warp the universe, notes strike shockwaves';
+            btn.addEventListener('click', async () => {
+                if (btn.dataset.active === 'false') {
+                    try {
+                        await midiInput.activate();
+                        _setActive(btn, true, true);
+                    } catch (err) {
+                        console.warn('[inputToolbar] MIDI activation failed:', err.message ?? err);
+                    }
+                } else {
+                    midiInput.deactivate();
+                    _setActive(btn, false, false);
+                }
+            });
+            _toolbar.appendChild(btn);
+            _buttons.midi = btn;
+        }
+
+        if (videoExport.supported) {
+            const btn = _makeButton('⏺', ACCENTS.record);
+            btn.title = 'Record a WebM clip of this universe (R)';
+            btn.addEventListener('click', () => videoExport.toggle());
+            _toolbar.appendChild(btn);
+            _buttons.record = btn;
+        }
+
         document.body.appendChild(_toolbar);
 
         document.addEventListener('keydown', (e) => {
@@ -176,6 +206,16 @@ export const inputToolbar = {
             const on = speechInput.active;
             const was = _buttons.speech.dataset.active === 'true';
             if (was !== on) _setActive(_buttons.speech, on, true);
+        }
+        if (_buttons.midi) {
+            const on = midiInput.active;
+            const was = _buttons.midi.dataset.active === 'true';
+            if (was !== on) _setActive(_buttons.midi, on, true);
+        }
+        if (_buttons.record) {
+            const on = videoExport.recording;
+            const was = _buttons.record.dataset.active === 'true';
+            if (was !== on) _setActive(_buttons.record, on, true);
         }
     },
 };

--- a/js/interactive_background_effects.js
+++ b/js/interactive_background_effects.js
@@ -2,7 +2,7 @@
  * @file interactive_background_effects.js
  * @description Orchestrator for the interactive effects layer that runs on top of all
  * background architectures. Uses a data-driven registry (effect_registry.js) to manage
- * 25 sub-systems with tag-based blueprint affinity selection.
+ * the effect sub-systems with tag-based blueprint affinity selection.
  *
  * Each universe seed selects 6-10 sub-systems weighted by thematic affinity with the
  * active blueprint, producing coherent interactive behaviors. Sub-systems are iterated

--- a/js/interactive_background_effects.js
+++ b/js/interactive_background_effects.js
@@ -8,12 +8,16 @@
  * active blueprint, producing coherent interactive behaviors. Sub-systems are iterated
  * via arrays instead of individual flags for maintainability.
  *
- * Also manages 6 lightweight original effects (ripples, mouse trail, gravity field,
- * heat map, echo ghosts, constellation links) inline.
+ * Cursor presence is provided by the cursor familiar (cursor_familiar.js): a seeded
+ * companion creature with follow/doze/startle behavior. It replaced the old generic
+ * inline effects (click ripples, mouse-trail ribbon, gravity field lines, heat map,
+ * echo ghosts, constellation links), which overlapped with the dedicated
+ * cursor_trails.js / cursor_effects.js layers without adding character.
  */
 
 import { mouse, isLeftMouseDown, isRightMouseDown } from './state.js';
 import { EFFECT_REGISTRY, selectEffects } from './effect_registry.js';
+import { cursorFamiliar } from './cursor_familiar.js';
 
 class InteractiveBackgroundEffects {
     constructor() {
@@ -25,56 +29,6 @@ class InteractiveBackgroundEffects {
         // Sorted draw order for active effects
         this._drawOrder = [];
 
-        // Original effect toggles
-        this.hasRipples = false;
-        this.hasMouseTrail = false;
-        this.hasGravityField = false;
-        this.hasHeatMap = false;
-        this.hasEchoGhosts = false;
-        this.hasConstellationLinks = false;
-
-        // Ripples
-        this.ripples = [];
-        this.ripplePool = [];
-        this.maxRipples = 12;
-
-        // Mouse trail
-        this.trailPoints = [];
-        this.maxTrailPoints = 40;
-        this.trailHue = 0;
-        this.trailWidth = 2;
-        this.trailStyle = 0;
-
-        // Gravity field
-        this.fieldLines = [];
-        this.fieldStrength = 0;
-        this.fieldHue = 0;
-
-        // Heat map - optimized with dirty tracking
-        this.heatGrid = null;
-        this.heatCols = 0;
-        this.heatRows = 0;
-        this.heatCellSize = 40;
-        this.heatDecay = 0.995;
-        this.heatHue = 0;
-        this._heatDirtyCells = new Set();
-
-        // Echo ghosts
-        this.ghosts = [];
-        this.ghostPool = [];
-        this.maxGhosts = 15;
-        this.ghostStyle = 0;
-
-        // Constellation links
-        this.constellationPoints = [];
-        this.maxConstellationPoints = 20;
-        this.constellationHue = 0;
-
-        // Click tracking
-        this._lastClickX = 0;
-        this._lastClickY = 0;
-        this._clickRegistered = false;
-
         // Quality scaling
         this._qualityScale = 1;
     }
@@ -82,12 +36,6 @@ class InteractiveBackgroundEffects {
     init() {
         if (this.initialized) return;
         this.initialized = true;
-
-        window.addEventListener('click', (e) => {
-            this._lastClickX = e.clientX;
-            this._lastClickY = e.clientY;
-            this._clickRegistered = true;
-        });
     }
 
     /**
@@ -121,11 +69,6 @@ class InteractiveBackgroundEffects {
      */
     configure(rng, palette, blueprintName) {
         this.tick = 0;
-        this.ripples = [];
-        this.trailPoints = [];
-        this.ghosts = [];
-        this.constellationPoints = [];
-        this._heatDirtyCells.clear();
 
         const hues = this._extractHues(palette);
 
@@ -144,48 +87,8 @@ class InteractiveBackgroundEffects {
             EFFECT_REGISTRY[idx].instance.configure(rng, hues);
         }
 
-        // --- Original effects (1-3 active) ---
-        this.hasRipples = rng() > 0.35;
-        this.hasMouseTrail = rng() > 0.5;
-        this.hasGravityField = rng() > 0.75;
-        this.hasHeatMap = rng() > 0.7;
-        this.hasEchoGhosts = rng() > 0.55;
-        this.hasConstellationLinks = rng() > 0.65;
-
-        // Parameterize original effects
-        this.trailHue = hues.length > 0 ? hues[0].h : 200;
-        this.trailWidth = 1 + rng() * 4;
-        this.trailStyle = Math.floor(rng() * 4);
-        this.fieldStrength = 0.5 + rng() * 1.5;
-        this.fieldHue = hues.length > 1 ? hues[1].h : 120;
-        this.heatHue = hues.length > 2 ? hues[2].h : 0;
-        this.heatDecay = 0.992 + rng() * 0.006;
-        this.ghostStyle = Math.floor(rng() * 3);
-        this.constellationHue = hues.length > 0 ? hues[0].h : 60;
-
-        this.rippleColor = `hsla(${this.trailHue}, 70%, 60%,`;
-        this.rippleSpeed = 3 + rng() * 5;
-        this.rippleMaxRadius = 80 + rng() * 120;
-
-        // Initialize heat grid
-        this.heatCols = Math.ceil(window.innerWidth / this.heatCellSize);
-        this.heatRows = Math.ceil(window.innerHeight / this.heatCellSize);
-        this.heatGrid = new Float32Array(this.heatCols * this.heatRows);
-
-        // Generate gravity field lines
-        if (this.hasGravityField) {
-            this.fieldLines = [];
-            const lineCount = 6 + Math.floor(rng() * 10);
-            for (let i = 0; i < lineCount; i++) {
-                this.fieldLines.push({
-                    angle: (i / lineCount) * Math.PI * 2,
-                    length: 50 + rng() * 150,
-                    width: 0.5 + rng() * 1.5,
-                    phase: rng() * Math.PI * 2,
-                    speed: 0.02 + rng() * 0.04,
-                });
-            }
-        }
+        // Every universe hatches a cursor familiar
+        cursorFamiliar.configure(rng, hues, blueprintName);
     }
 
     /**
@@ -198,133 +101,6 @@ class InteractiveBackgroundEffects {
         const my = mouse.y;
         const isClicking = isLeftMouseDown || isRightMouseDown;
 
-        const dx = mx - (this._prevMx || mx);
-        const dy = my - (this._prevMy || my);
-        this._mouseSpeed = Math.sqrt(dx * dx + dy * dy);
-        this._prevMx = mx;
-        this._prevMy = my;
-
-        // Handle clicks for original effects
-        if (this._clickRegistered) {
-            this._clickRegistered = false;
-
-            if (this.hasRipples && this.ripples.length < this.maxRipples) {
-                const ripple = this.ripplePool.length > 0 ? this.ripplePool.pop() : {};
-                ripple.x = this._lastClickX;
-                ripple.y = this._lastClickY;
-                ripple.radius = 0;
-                ripple.alpha = 0.6;
-                ripple.hue = (this.trailHue + ((this.tick * 2654435761) >>> 0) / 4294967296 * 60 - 30 + 360) % 360;
-                this.ripples.push(ripple);
-            }
-
-            if (this.hasConstellationLinks) {
-                this.constellationPoints.push({
-                    x: this._lastClickX,
-                    y: this._lastClickY,
-                    life: 300,
-                    alpha: 0.5,
-                });
-                if (this.constellationPoints.length > this.maxConstellationPoints) {
-                    this.constellationPoints[0] = this.constellationPoints[this.constellationPoints.length - 1];
-                    this.constellationPoints.pop();
-                }
-            }
-        }
-
-        // Update ripples
-        for (let i = this.ripples.length - 1; i >= 0; i--) {
-            const r = this.ripples[i];
-            r.radius += this.rippleSpeed;
-            r.alpha = Math.max(0, 1 - r.radius / this.rippleMaxRadius) * 0.4;
-            if (r.radius > this.rippleMaxRadius) {
-                this.ripplePool.push(r);
-                this.ripples[i] = this.ripples[this.ripples.length - 1];
-                this.ripples.pop();
-            }
-        }
-
-        // Mouse trail - ring buffer style to avoid .slice() GC pressure
-        if (this.hasMouseTrail) {
-            if (this.trailPoints.length < this.maxTrailPoints) {
-                this.trailPoints.push({ x: mx, y: my, tick: this.tick });
-            } else {
-                // Overwrite oldest entry using a write index
-                if (this._trailWriteIdx === undefined) this._trailWriteIdx = 0;
-                const tp = this.trailPoints[this._trailWriteIdx];
-                tp.x = mx; tp.y = my; tp.tick = this.tick;
-                this._trailWriteIdx = (this._trailWriteIdx + 1) % this.maxTrailPoints;
-            }
-        }
-
-        // Heat map
-        if (this.hasHeatMap && this.heatGrid) {
-            const hx = Math.floor(mx / this.heatCellSize);
-            const hy = Math.floor(my / this.heatCellSize);
-            if (hx >= 0 && hx < this.heatCols && hy >= 0 && hy < this.heatRows) {
-                for (let dy2 = -1; dy2 <= 1; dy2++) {
-                    for (let dx2 = -1; dx2 <= 1; dx2++) {
-                        const nx = hx + dx2;
-                        const ny = hy + dy2;
-                        if (nx >= 0 && nx < this.heatCols && ny >= 0 && ny < this.heatRows) {
-                            const idx = ny * this.heatCols + nx;
-                            const dist = Math.abs(dx2) + Math.abs(dy2);
-                            this.heatGrid[idx] = Math.min(1,
-                                this.heatGrid[idx] + (dist === 0 ? 0.05 : 0.02));
-                            this._heatDirtyCells.add(idx);
-                        }
-                    }
-                }
-            }
-            if (this.tick % 2 === 0) {
-                // Iterate and delete in-place to avoid temp array GC pressure
-                for (const idx of this._heatDirtyCells) {
-                    this.heatGrid[idx] *= this.heatDecay;
-                    if (this.heatGrid[idx] < 0.005) {
-                        this.heatGrid[idx] = 0;
-                        this._heatDirtyCells.delete(idx);
-                    }
-                }
-            }
-        }
-
-        // Echo ghosts - use simple LCG to avoid Math.random() for determinism
-        const ghostInterval = Math.max(2, 6 - Math.floor(this._mouseSpeed || 0));
-        if (this.hasEchoGhosts && this.tick % ghostInterval === 0 && this.ghosts.length < this.maxGhosts) {
-            const ghost = this.ghostPool.length > 0 ? this.ghostPool.pop() : {};
-            ghost.x = mx;
-            ghost.y = my;
-            ghost.life = 30;
-            ghost.maxLife = 30;
-            // Use tick-based pseudo-random to avoid non-deterministic Math.random()
-            const pr = ((this.tick * 2654435761) >>> 0) / 4294967296;
-            const pr2 = ((this.tick * 2246822519) >>> 0) / 4294967296;
-            ghost.size = 8 + pr * 12;
-            ghost.style = Math.floor(pr2 * 3);
-            ghost.hueOffset = pr * 40 - 20;
-            this.ghosts.push(ghost);
-        }
-
-        for (let i = this.ghosts.length - 1; i >= 0; i--) {
-            this.ghosts[i].life--;
-            if (this.ghosts[i].life <= 0) {
-                this.ghostPool.push(this.ghosts[i]);
-                this.ghosts[i] = this.ghosts[this.ghosts.length - 1];
-                this.ghosts.pop();
-            }
-        }
-
-        // Constellation lifetimes
-        for (let i = this.constellationPoints.length - 1; i >= 0; i--) {
-            const cp = this.constellationPoints[i];
-            cp.life--;
-            cp.alpha = Math.min(0.5, cp.life / 100);
-            if (cp.life <= 0) {
-                this.constellationPoints[i] = this.constellationPoints[this.constellationPoints.length - 1];
-                this.constellationPoints.pop();
-            }
-        }
-
         // Update active sub-systems via registry
         const q = this._qualityScale;
         for (const idx of this._activeIndices) {
@@ -333,6 +109,8 @@ class InteractiveBackgroundEffects {
                 entry.instance.update(mx, my, isClicking);
             }
         }
+
+        cursorFamiliar.update(mx, my, isClicking);
     }
 
     /**
@@ -351,207 +129,8 @@ class InteractiveBackgroundEffects {
             }
         }
 
-        // --- Original effects below ---
-
-        // Heat map — batch into 4 heat bands to reduce fillStyle changes
-        if (this.hasHeatMap && this.heatGrid && this._heatDirtyCells.size > 0) {
-            ctx.save();
-            ctx.globalCompositeOperation = 'lighter';
-            const bands = [0.01, 0.25, 0.5, 0.75];
-            const cs = this.heatCellSize;
-            const cols = this.heatCols;
-            for (let b = 0; b < bands.length; b++) {
-                const lo = bands[b];
-                const hi = b < bands.length - 1 ? bands[b + 1] : 1.01;
-                const midHeat = (lo + hi) / 2;
-                const alpha = midHeat * 0.15;
-                const lightness = 40 + midHeat * 30;
-                ctx.fillStyle = `hsla(${this.heatHue + midHeat * 60}, 80%, ${lightness}%, ${alpha})`;
-                ctx.beginPath();
-                for (const idx of this._heatDirtyCells) {
-                    const heat = this.heatGrid[idx];
-                    if (heat >= lo && heat < hi) {
-                        const x = (idx % cols) * cs;
-                        const y = Math.floor(idx / cols) * cs;
-                        ctx.rect(x, y, cs, cs);
-                    }
-                }
-                ctx.fill();
-            }
-            ctx.restore();
-        }
-
-        // Gravity field lines - use pre-computed color to avoid gradient alloc per line
-        if (this.hasGravityField) {
-            ctx.save();
-            ctx.globalCompositeOperation = 'lighter';
-            const mx = mouse.x;
-            const my = mouse.y;
-            for (const line of this.fieldLines) {
-                const a = line.angle + Math.sin(this.tick * line.speed + line.phase) * 0.3;
-                const len = line.length + Math.sin(this.tick * 0.02 + line.phase) * 20;
-                const cosA = Math.cos(a);
-                const sinA = Math.sin(a);
-                const x1 = mx + cosA * 15;
-                const y1 = my + sinA * 15;
-                const x2 = mx + cosA * len;
-                const y2 = my + sinA * len;
-                // Fade alpha along length using globalAlpha instead of per-line gradient
-                const alpha = 0.2 * (len / (line.length + 20));
-                ctx.strokeStyle = `hsla(${this.fieldHue}, 60%, 60%, ${alpha})`;
-                ctx.lineWidth = line.width;
-                ctx.beginPath();
-                ctx.moveTo(x1, y1);
-                ctx.lineTo(x2, y2);
-                ctx.stroke();
-            }
-            ctx.restore();
-        }
-
-        // Echo ghosts
-        if (this.hasEchoGhosts) {
-            ctx.save();
-            ctx.globalCompositeOperation = 'lighter';
-            for (const ghost of this.ghosts) {
-                const alpha = (ghost.life / ghost.maxLife) * 0.2;
-                const size = ghost.size * (1 - ghost.life / ghost.maxLife) + ghost.size * 0.5;
-                const ghostHue = (this.trailHue + (ghost.hueOffset || 0) + 360) % 360;
-                ctx.strokeStyle = `hsla(${ghostHue}, 50%, 60%, ${alpha})`;
-                ctx.lineWidth = 1;
-                const style = ghost.style !== undefined ? ghost.style : this.ghostStyle;
-                if (style === 0) {
-                    ctx.beginPath(); ctx.arc(ghost.x, ghost.y, size, 0, Math.PI * 2); ctx.stroke();
-                } else if (style === 1) {
-                    ctx.beginPath(); ctx.arc(ghost.x, ghost.y, size, 0, Math.PI * 2); ctx.stroke();
-                    ctx.beginPath(); ctx.arc(ghost.x, ghost.y, size * 0.5, 0, Math.PI * 2); ctx.stroke();
-                } else {
-                    ctx.beginPath();
-                    ctx.moveTo(ghost.x - size, ghost.y); ctx.lineTo(ghost.x + size, ghost.y);
-                    ctx.moveTo(ghost.x, ghost.y - size); ctx.lineTo(ghost.x, ghost.y + size);
-                    ctx.stroke();
-                }
-            }
-            ctx.restore();
-        }
-
-        // Mouse trail ribbon — sort by tick to get correct temporal order from ring buffer
-        if (this.hasMouseTrail && this.trailPoints.length > 2) {
-            ctx.save();
-            ctx.globalCompositeOperation = 'lighter';
-            ctx.lineWidth = this.trailWidth;
-            ctx.lineCap = 'round';
-            ctx.lineJoin = 'round';
-
-            // Build ordered view of ring buffer without allocating a new array:
-            // find the oldest entry and iterate from there
-            const pts = this.trailPoints;
-            const len = pts.length;
-            let startIdx = 0;
-            if (this._trailWriteIdx !== undefined && len === this.maxTrailPoints) {
-                startIdx = this._trailWriteIdx; // oldest entry
-            }
-
-            if (this.trailStyle === 3) {
-                for (let j = 1; j < len; j++) {
-                    const prev = pts[(startIdx + j - 1) % len];
-                    const curr = pts[(startIdx + j) % len];
-                    const alpha = j / len;
-                    const hue = (this.trailHue + j * 8) % 360;
-                    ctx.strokeStyle = `hsla(${hue}, 70%, 60%, ${alpha * 0.3})`;
-                    ctx.beginPath();
-                    ctx.moveTo(prev.x, prev.y);
-                    ctx.lineTo(curr.x, curr.y);
-                    ctx.stroke();
-                }
-            } else if (this.trailStyle === 1) {
-                for (let j = 0; j < len; j += 2) {
-                    const p = pts[(startIdx + j) % len];
-                    const alpha = j / len;
-                    ctx.fillStyle = `hsla(${this.trailHue}, 60%, 60%, ${alpha * 0.3})`;
-                    ctx.beginPath();
-                    ctx.arc(p.x, p.y, this.trailWidth, 0, Math.PI * 2);
-                    ctx.fill();
-                }
-            } else {
-                const first = pts[startIdx % len];
-                ctx.beginPath();
-                ctx.moveTo(first.x, first.y);
-                for (let j = 1; j < len; j++) {
-                    const p = pts[(startIdx + j) % len];
-                    ctx.lineTo(p.x, p.y);
-                }
-                ctx.strokeStyle = `hsla(${this.trailHue}, 60%, 60%, 0.25)`;
-                ctx.stroke();
-            }
-            ctx.restore();
-        }
-
-        // Click ripples
-        if (this.hasRipples) {
-            ctx.save();
-            ctx.globalCompositeOperation = 'lighter';
-            ctx.lineWidth = 1.5;
-            for (const r of this.ripples) {
-                const rHue = r.hue !== undefined ? r.hue : this.trailHue;
-                ctx.strokeStyle = `hsla(${rHue}, 70%, 60%, ${r.alpha})`;
-                ctx.beginPath(); ctx.arc(r.x, r.y, r.radius, 0, Math.PI * 2); ctx.stroke();
-                if (r.radius > 10) {
-                    ctx.strokeStyle = `hsla(${rHue}, 70%, 60%, ${r.alpha * 0.5})`;
-                    ctx.beginPath(); ctx.arc(r.x, r.y, r.radius * 0.6, 0, Math.PI * 2); ctx.stroke();
-                }
-            }
-            ctx.restore();
-        }
-
-        // Constellation links - batch lines into single path when possible, use distSq for alpha approx
-        if (this.hasConstellationLinks && this.constellationPoints.length > 1) {
-            ctx.save();
-            ctx.globalCompositeOperation = 'lighter';
-            ctx.lineWidth = 0.5;
-            const maxDistSq = 90000; // 300^2
-            const invMaxDist = 1 / 300;
-            const cHue = this.constellationHue;
-
-            // Batch all lines at a single average alpha for performance
-            ctx.beginPath();
-            let batchAlpha = 0;
-            let lineCount = 0;
-            for (let i = 0; i < this.constellationPoints.length; i++) {
-                const p1 = this.constellationPoints[i];
-                for (let j = i + 1; j < this.constellationPoints.length; j++) {
-                    const p2 = this.constellationPoints[j];
-                    const cdx = p1.x - p2.x;
-                    const cdy = p1.y - p2.y;
-                    const distSq = cdx * cdx + cdy * cdy;
-                    if (distSq < maxDistSq) {
-                        // Use distSq ratio to avoid expensive Math.sqrt
-                        const alpha = Math.min(p1.alpha, p2.alpha) * (1 - distSq / maxDistSq) * 0.3;
-                        batchAlpha += alpha;
-                        lineCount++;
-                        ctx.moveTo(p1.x, p1.y);
-                        ctx.lineTo(p2.x, p2.y);
-                    }
-                }
-            }
-            if (lineCount > 0) {
-                ctx.strokeStyle = `hsla(${cHue}, 50%, 70%, ${batchAlpha / lineCount})`;
-                ctx.stroke();
-            }
-
-            // Draw dots
-            for (let i = 0; i < this.constellationPoints.length; i++) {
-                const p1 = this.constellationPoints[i];
-                const dotAlpha = p1.alpha * 0.6;
-                const freshness = p1.life > 250 ? (p1.life - 250) / 50 : 0;
-                if (freshness > 0) {
-                    ctx.fillStyle = `hsla(${cHue}, 80%, 85%, ${dotAlpha * freshness * 0.5})`;
-                    ctx.beginPath(); ctx.arc(p1.x, p1.y, 6, 0, Math.PI * 2); ctx.fill();
-                }
-                ctx.fillStyle = `hsla(${cHue}, 60%, 80%, ${dotAlpha})`;
-                ctx.beginPath(); ctx.arc(p1.x, p1.y, 2, 0, Math.PI * 2); ctx.fill();
-            }
-            ctx.restore();
-        }
+        // The familiar draws last: it should always read on top of the scenery
+        cursorFamiliar.draw(ctx, system);
     }
 }
 

--- a/js/journal.js
+++ b/js/journal.js
@@ -1,0 +1,171 @@
+/**
+ * @file journal.js
+ * @description The constellation journal: a localStorage-backed field
+ * notebook that automatically logs every universe you visit — seed, epithet,
+ * blueprint, lineage generation, visit count, and when you last saw it.
+ * Press J to leaf through it; clicking an entry travels back to that
+ * universe. Capped at 150 entries, oldest-seen evicted first.
+ *
+ * CSP-safe: built entirely with createElement/textContent.
+ */
+
+import { loreCodex } from './lore_codex.js';
+import { parseLineage, toRoman } from './epoch_system.js';
+
+const STORAGE_KEY = 'celestial-journal';
+const MAX_ENTRIES = 150;
+
+function timeAgo(ts) {
+    const s = Math.max(1, (Date.now() - ts) / 1000);
+    if (s < 90) return 'just now';
+    if (s < 3600) return `${Math.round(s / 60)}m ago`;
+    if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+    return `${Math.round(s / 86400)}d ago`;
+}
+
+export const journal = {
+    _entries: [],
+    _overlay: null,
+    _list: null,
+    _isOpen: false,
+
+    init() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                if (Array.isArray(parsed)) this._entries = parsed;
+            }
+        } catch (err) { /* private mode etc. — journal lives for the session */ }
+
+        document.addEventListener('keydown', (e) => {
+            const el = document.activeElement;
+            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+            if (e.key === 'Escape' && this._isOpen) this.close();
+            else if ((e.key === 'j' || e.key === 'J') && !e.ctrlKey && !e.metaKey && !e.altKey) this.toggle();
+        });
+    },
+
+    /** Log a visit. Called from universe.js after the lore is written. */
+    record(seed, blueprintName) {
+        if (!seed) return;
+        const now = Date.now();
+        const existing = this._entries.find((en) => en.seed === seed);
+        if (existing) {
+            existing.visits++;
+            existing.ts = now;
+        } else {
+            this._entries.push({
+                seed,
+                epithet: loreCodex.current ? loreCodex.current.epithet : '',
+                blueprint: blueprintName || '',
+                generation: parseLineage(seed).generation,
+                visits: 1,
+                ts: now,
+            });
+            if (this._entries.length > MAX_ENTRIES) {
+                this._entries.sort((a, b) => b.ts - a.ts);
+                this._entries.length = MAX_ENTRIES;
+            }
+        }
+        this._save();
+        if (this._isOpen) this._renderList();
+    },
+
+    _save() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this._entries));
+        } catch (err) { /* best effort */ }
+    },
+
+    toggle() {
+        if (this._isOpen) this.close();
+        else this.open();
+    },
+
+    open() {
+        if (!this._overlay) this._build();
+        this._renderList();
+        this._overlay.style.display = 'flex';
+        requestAnimationFrame(() => { this._overlay.style.opacity = '1'; });
+        this._isOpen = true;
+    },
+
+    close() {
+        if (!this._overlay) return;
+        this._overlay.style.opacity = '0';
+        setTimeout(() => { this._overlay.style.display = 'none'; }, 250);
+        this._isOpen = false;
+    },
+
+    _build() {
+        const overlay = document.createElement('div');
+        overlay.style.cssText =
+            'position:fixed;inset:0;z-index:200;display:none;flex-direction:column;align-items:center;' +
+            'background:rgba(5,5,10,0.82);backdrop-filter:blur(10px);opacity:0;transition:opacity 0.25s;' +
+            'font-family:"Exo 2",sans-serif;overflow-y:auto;padding:48px 16px;box-sizing:border-box;cursor:default;';
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) this.close(); });
+
+        const title = document.createElement('h2');
+        title.textContent = 'Constellation Journal';
+        title.style.cssText = 'margin:0 0 4px;font-weight:300;letter-spacing:5px;text-transform:uppercase;font-size:18px;color:rgba(255,255,255,0.9);';
+
+        const subtitle = document.createElement('p');
+        subtitle.style.cssText = 'margin:0 0 24px;font-size:11px;color:rgba(255,255,255,0.4);font-style:italic;';
+
+        this._subtitle = subtitle;
+        this._list = document.createElement('div');
+        this._list.style.cssText = 'display:flex;flex-direction:column;gap:8px;width:min(680px,94vw);';
+
+        overlay.appendChild(title);
+        overlay.appendChild(subtitle);
+        overlay.appendChild(this._list);
+        document.body.appendChild(overlay);
+        this._overlay = overlay;
+    },
+
+    _renderList() {
+        const list = this._list;
+        while (list.firstChild) list.removeChild(list.firstChild);
+
+        const entries = [...this._entries].sort((a, b) => b.ts - a.ts);
+        this._subtitle.textContent = entries.length
+            ? `${entries.length} charted universe${entries.length === 1 ? '' : 's'} · click one to travel · Esc to close`
+            : 'No universes charted yet — they are logged as you travel.';
+
+        for (const en of entries) {
+            const row = document.createElement('div');
+            row.style.cssText =
+                'display:flex;align-items:baseline;gap:12px;padding:10px 16px;border-radius:10px;cursor:pointer;' +
+                'background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.08);transition:background 0.15s;';
+            row.addEventListener('mouseenter', () => { row.style.background = 'rgba(255,255,255,0.12)'; });
+            row.addEventListener('mouseleave', () => { row.style.background = 'rgba(255,255,255,0.05)'; });
+            row.addEventListener('click', () => {
+                window.location.search = '?seed=' + encodeURIComponent(en.seed);
+            });
+
+            const epithet = document.createElement('span');
+            epithet.textContent = en.epithet || '“Uncharted”';
+            epithet.style.cssText = 'font-style:italic;font-size:14px;color:rgba(255,255,255,0.92);flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+
+            const meta = document.createElement('span');
+            const genText = en.generation > 1 ? ` · Gen ${toRoman(en.generation)}` : '';
+            meta.textContent = `${en.blueprint}${genText}`;
+            meta.style.cssText = 'font-size:10px;color:rgba(255,220,170,0.55);white-space:nowrap;';
+
+            const seed = document.createElement('span');
+            seed.textContent = en.seed;
+            seed.style.cssText = 'font-family:monospace;font-size:10px;color:rgba(255,255,255,0.45);white-space:nowrap;';
+
+            const when = document.createElement('span');
+            when.textContent = `${en.visits > 1 ? en.visits + '× · ' : ''}${timeAgo(en.ts)}`;
+            when.style.cssText = 'font-size:10px;color:rgba(255,255,255,0.3);white-space:nowrap;';
+
+            row.appendChild(epithet);
+            row.appendChild(meta);
+            row.appendChild(seed);
+            row.appendChild(when);
+            list.appendChild(row);
+        }
+    },
+};

--- a/js/lore_codex.js
+++ b/js/lore_codex.js
@@ -1,0 +1,145 @@
+/**
+ * @file lore_codex.js
+ * @description Procedural field guide: every universe gets a deterministic
+ * epithet ("The Drowned Chandelier") and a surveyor's field note written by a
+ * seeded grammar, themed to the active blueprint. Pure text generation — no
+ * DOM — so the HUD just reads `loreCodex.current`.
+ */
+
+/** Map each blueprint to a lore theme bank. Unknown blueprints fall back to 'cosmic'. */
+const BLUEPRINT_THEME = {
+    Classical: 'cosmic', StarForged: 'cosmic', StellarNursery: 'cosmic',
+    CelestialForge: 'cosmic', LivingConstellation: 'cosmic', ChronoVerse: 'temporal',
+    PhantomEcho: 'temporal', HauntedRealm: 'void', VoidTouched: 'void',
+    Eldritch: 'void', AbyssalHorror: 'void', QuantumFoam: 'temporal',
+    Organic: 'organic', BioMechanical: 'organic', SentientSwarm: 'organic',
+    FungalForest: 'organic', CoralReef: 'aquatic', AbyssalZone: 'aquatic',
+    GlassySea: 'aquatic', GooeyMess: 'organic', Digital: 'digital',
+    TechnoUtopia: 'digital', NeonCyber: 'digital', Crystalline: 'crystal',
+    GlacialDrift: 'crystal', ArcaneCodex: 'crystal', Papercraft: 'craft',
+    SilkWeaver: 'craft', Painterly: 'craft', LivingInk: 'craft',
+    ChromaticAberration: 'craft', MoltenHeart: 'fire', VolcanicForge: 'fire',
+    SonicScapes: 'sonic', Aetherial: 'ethereal',
+};
+
+const EPITHET_ADJ = {
+    cosmic: ['Unblinking', 'Ten-Thousand-Year', 'Slow-Burning', 'Orphaned', 'Cartwheeling', 'Half-Lit'],
+    temporal: ['Twice-Remembered', 'Unfinished', 'Rewound', 'Borrowed', 'Out-of-Step', 'Yesterday’s'],
+    void: ['Drowned', 'Hollow', 'Unspoken', 'Inverted', 'Sleepless', 'Forgotten'],
+    organic: ['Budding', 'Overgrown', 'Breathing', 'Many-Handed', 'Spored', 'Warm-Blooded'],
+    aquatic: ['Tide-Locked', 'Brackish', 'Pearl-Bottomed', 'Slow-Sinking', 'Bioluminous', 'Drift-Borne'],
+    digital: ['Self-Compiling', 'Checksummed', 'Overclocked', 'Mirrorless', 'Hot-Swapped', 'Procedural'],
+    crystal: ['Faceted', 'Annealed', 'Prismatic', 'Frost-Veined', 'Lapidary', 'Unmelting'],
+    craft: ['Hand-Folded', 'Unvarnished', 'Loose-Threaded', 'Overpainted', 'Dog-Eared', 'Freshly-Inked'],
+    fire: ['Smoldering', 'Anvil-Bright', 'Cinder-Choked', 'Twice-Forged', 'Unquenched', 'Bellowed'],
+    sonic: ['Resonant', 'Off-Key', 'Twelve-Toned', 'Echo-Laden', 'Tuned', 'Reverberant'],
+    ethereal: ['Gossamer', 'Half-Dreamt', 'Featherweight', 'Dawn-Colored', 'Translucent', 'Hushed'],
+};
+
+const EPITHET_NOUN = {
+    cosmic: ['Carousel', 'Lighthouse', 'Orrery', 'Atlas', 'Furnace', 'Procession'],
+    temporal: ['Metronome', 'Palimpsest', 'Antechamber', 'Rehearsal', 'Calendar', 'Pendulum'],
+    void: ['Chandelier', 'Cathedral', 'Aquifer', 'Reliquary', 'Audience', 'Door'],
+    organic: ['Garden', 'Hive', 'Rookery', 'Orchard', 'Menagerie', 'Root-Cellar'],
+    aquatic: ['Lagoon', 'Ballroom', 'Shipyard', 'Estuary', 'Aquarium', 'Undertow'],
+    digital: ['Mainframe', 'Arcade', 'Switchboard', 'Archive', 'Bazaar', 'Compiler'],
+    crystal: ['Geode', 'Conservatory', 'Chandlery', 'Vault', 'Terrarium', 'Mosaic'],
+    craft: ['Atelier', 'Diorama', 'Loom', 'Sketchbook', 'Marionette', 'Bindery'],
+    fire: ['Foundry', 'Hearth', 'Kiln', 'Procession', 'Crucible', 'Parade'],
+    sonic: ['Choir', 'Carillon', 'Amphitheater', 'Tuning-Fork', 'Jukebox', 'Aviary'],
+    ethereal: ['Veil', 'Greenhouse', 'Balloon-Field', 'Apiary', 'Cloudbank', 'Lullaby'],
+};
+
+const SURVEYORS = [
+    'the Cartographer Adrift', 'Survey Barge “Second Thoughts”', 'an unmanned lantern probe',
+    'the Sisters of the Measured Mile', 'a retired comet-courier', 'the Bureau of Improbable Weather',
+    'deep-field monk-astronomers', 'the lighthouse keeper at Relay 9',
+];
+
+const OBSERVATIONS = {
+    cosmic: [
+        'Stars here set in pairs, out of politeness.',
+        'Gravity files a complaint roughly every third orbit.',
+        'The nebulae rearrange themselves when nobody charts them.',
+    ],
+    temporal: [
+        'Echoes arrive a few seconds before their sounds.',
+        'Local clocks agree only on the hour of dusk.',
+        'Yesterday is visible from high ground.',
+    ],
+    void: [
+        'The dark is load-bearing; do not lean on it.',
+        'Something counts along with you, half a beat late.',
+        'Lanterns burn here, but their light arrives reluctantly.',
+    ],
+    organic: [
+        'The undergrowth rearranges itself toward warm voices.',
+        'Spores log every visitor; the census is never wrong.',
+        'Do not prune anything that hums.',
+    ],
+    aquatic: [
+        'The tide goes out once a year and comes back curious.',
+        'Bioluminescence spells short words after midnight.',
+        'Depth is negotiable; bring a flexible ruler.',
+    ],
+    digital: [
+        'The skyline recompiles at dawn with no downtime.',
+        'Packets migrate south along the old bus routes.',
+        'A checksum error in sector 9 is now a public fountain.',
+    ],
+    crystal: [
+        'Every surface keeps a copy of the light it has seen.',
+        'Frost grows in perfect quotations of nearby shapes.',
+        'Handle the silence carefully; it is faceted.',
+    ],
+    craft: [
+        'The horizon is hemmed, not finished.',
+        'Paint dries here into weather.',
+        'Folded corners of the sky still show pencil marks.',
+    ],
+    fire: [
+        'The forges sing shift-songs in eleven-hour days.',
+        'Ash falls upward on feast days.',
+        'Magma keeps appointments; eruptions are merely punctual.',
+    ],
+    sonic: [
+        'Architecture is just frozen reverb here.',
+        'The wind rehearses; premieres are seasonal.',
+        'Every canyon returns your call within three business days.',
+    ],
+    ethereal: [
+        'Clouds graze in herds and answer to whistles.',
+        'Morning is optional but well attended.',
+        'Light pools in low places like rain.',
+    ],
+};
+
+const VERDICTS = [
+    'Habitability: pending appeal.', 'Recommended visit length: one held breath.',
+    'Charted, reluctantly.', 'Survey incomplete; surveyor enchanted.',
+    'Filed under: do not wake.', 'Status: louder than documented.',
+    'Approved for dreams and short layovers.', 'Re-survey scheduled for never, fondly.',
+];
+
+function pick(rng, arr) {
+    return arr[Math.floor(rng() * arr.length)];
+}
+
+export const loreCodex = {
+    /** @type {{ epithet: string, note: string } | null} */
+    current: null,
+
+    /**
+     * Generate deterministic lore for a universe. Call once per generation.
+     * @param {function} rng - seeded RNG
+     * @param {string} blueprintName
+     * @returns {{ epithet: string, note: string }}
+     */
+    generate(rng, blueprintName) {
+        const theme = BLUEPRINT_THEME[blueprintName] || 'cosmic';
+        const epithet = `“The ${pick(rng, EPITHET_ADJ[theme])} ${pick(rng, EPITHET_NOUN[theme])}”`;
+        const note = `Logged by ${pick(rng, SURVEYORS)}. ${pick(rng, OBSERVATIONS[theme])} ${pick(rng, VERDICTS)}`;
+        this.current = { epithet, note };
+        return this.current;
+    },
+};

--- a/js/main.js
+++ b/js/main.js
@@ -37,10 +37,14 @@ import { embedMode } from './embed_mode.js';
 import { multiMonitor } from './multi_monitor.js';
 import { loadingAnimation } from './loading_animation.js';
 import { interactiveEffects } from './interactive_background_effects.js';
+import { environmentSense } from './environment_sense.js';
+import { videoExport } from './video_export.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     // --- Loading animation (must be first) ---
     loadingAnimation.init();
+    // Environment awareness must precede the render loop (quality cap, calm mode)
+    environmentSense.init();
 
     // --- Initial Load ---
     particlesJS('particles-js', baseConfig);
@@ -73,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
     themeEditor.init();
     multiMonitor.init();
     interactiveEffects.init();
+    videoExport.init();
     embedMode.init();
 
     initializeEventListeners(pJS);

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,7 @@
  */
 
 import { baseConfig } from './config.js';
+import { createParticleEngine } from './particle_engine.js';
 import { generateUniverse } from './universe.js';
 import { update } from './simulation.js';
 import { initializeEventListeners } from './ui.js';
@@ -41,6 +42,7 @@ import { environmentSense } from './environment_sense.js';
 import { videoExport } from './video_export.js';
 import { familiarMemory } from './familiar_memory.js';
 import { postcard } from './postcard.js';
+import { journal } from './journal.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     // --- Loading animation (must be first) ---
@@ -49,10 +51,12 @@ document.addEventListener('DOMContentLoaded', () => {
     environmentSense.init();
     // Familiar memory must load before the first universe configures its familiar
     familiarMemory.init();
+    // Journal must load before the first universe records itself
+    journal.init();
 
     // --- Initial Load ---
-    particlesJS('particles-js', baseConfig);
-    const pJS = window.pJSDom[0].pJS;
+    // In-house engine (particle_engine.js) — no CDN dependency
+    const pJS = createParticleEngine('particles-js', baseConfig);
     const urlParams = new URLSearchParams(window.location.search);
 
     background.init();
@@ -88,4 +92,9 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeEventListeners(pJS);
     generateUniverse(pJS, urlParams.get('seed'));
     requestAnimationFrame(() => update(pJS));
+
+    // Installable / offline-capable (sw.js caches the app shell + modules)
+    if ('serviceWorker' in navigator && location.protocol === 'https:') {
+        navigator.serviceWorker.register('sw.js').catch(() => { /* offline mode unavailable */ });
+    }
 });

--- a/js/main.js
+++ b/js/main.js
@@ -39,12 +39,16 @@ import { loadingAnimation } from './loading_animation.js';
 import { interactiveEffects } from './interactive_background_effects.js';
 import { environmentSense } from './environment_sense.js';
 import { videoExport } from './video_export.js';
+import { familiarMemory } from './familiar_memory.js';
+import { postcard } from './postcard.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     // --- Loading animation (must be first) ---
     loadingAnimation.init();
     // Environment awareness must precede the render loop (quality cap, calm mode)
     environmentSense.init();
+    // Familiar memory must load before the first universe configures its familiar
+    familiarMemory.init();
 
     // --- Initial Load ---
     particlesJS('particles-js', baseConfig);
@@ -78,6 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
     multiMonitor.init();
     interactiveEffects.init();
     videoExport.init();
+    postcard.init();
     embedMode.init();
 
     initializeEventListeners(pJS);

--- a/js/metro_map_generator.js
+++ b/js/metro_map_generator.js
@@ -1,0 +1,397 @@
+/**
+ * @file metro_map_generator.js
+ * @description Seeded procedural generator for schematic transit ("metro") maps.
+ * Produces octilinear line geometry — horizontal/vertical/45° runs joined by
+ * rounded corners, the visual grammar of real subway diagrams — plus station
+ * placement with interchange clustering and an optional octilinear river band.
+ *
+ * Four topologies, picked per seed:
+ *  - weave:     crosshatch of horizontal-ish and vertical-ish lines (+ rare diagonal)
+ *  - spokes:    3-4 straight diameter lines through a hub, optional ring
+ *  - orbital:   two concentric ring lines threaded by straight diameters
+ *  - riverside: lines hugging both banks of a river, bridged by crossing lines
+ *
+ * Pure geometry: no DOM or canvas access, so it is cheap to test and reuse.
+ * Rendering and interaction live in metro_transit_effects.js.
+ */
+
+const TAU = Math.PI * 2;
+
+function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+/**
+ * Core octilinear walk along a dominant axis `u` with 45° jogs in `v`.
+ * Endpoint v is soft — jogs are biased toward evTarget but the line is allowed
+ * to land wherever its last run ends, which keeps generation robust.
+ */
+function octiWalk(rng, su, sv, eu, evTarget, jogs, vMin, vMax) {
+    const pts = [{ u: su, v: sv }];
+    const dirU = eu > su ? 1 : -1;
+    const span = Math.abs(eu - su);
+    const fr = [];
+    for (let i = 0; i < jogs; i++) fr.push(0.12 + rng() * 0.74);
+    fr.sort((a, b) => a - b);
+    let u = su;
+    let v = sv;
+    for (let i = 0; i < jogs; i++) {
+        const ju = su + dirU * span * fr[i];
+        if ((ju - u) * dirU < 16) continue; // too close to the previous corner
+        const nextU = i + 1 < jogs ? su + dirU * span * fr[i + 1] : eu;
+        const maxMag = Math.abs(nextU - ju) * 0.85;
+        const want = (evTarget - v) * (0.35 + rng() * 0.65) + (rng() - 0.5) * span * 0.22;
+        let mag = Math.min(Math.abs(want), maxMag);
+        if (mag < 26) continue;
+        const sgn = want < 0 ? -1 : 1;
+        const nv = clamp(v + sgn * mag, vMin, vMax);
+        mag = Math.abs(nv - v);
+        if (mag < 26) continue;
+        pts.push({ u: ju, v });
+        u = ju + dirU * mag;
+        v = nv;
+        pts.push({ u, v });
+    }
+    pts.push({ u: eu, v });
+    return pts;
+}
+
+/**
+ * Octilinear path from (sx,sy) toward (ex,ey). The dominant axis is travelled
+ * fully; the cross axis is approached via 45° jogs.
+ */
+export function octilinearPath(rng, sx, sy, ex, ey, jogs, xMin, xMax, yMin, yMax) {
+    if (Math.abs(ex - sx) >= Math.abs(ey - sy)) {
+        return octiWalk(rng, sx, sy, ex, ey, jogs, yMin, yMax).map(p => ({ x: p.u, y: p.v }));
+    }
+    return octiWalk(rng, sy, sx, ey, ex, jogs, xMin, xMax).map(p => ({ x: p.v, y: p.u }));
+}
+
+/** Quadratic-sample a corner: in-point, 3 curve samples through b, out-point. */
+function pushRoundedCorner(out, a, b, c, radius) {
+    const d1 = Math.hypot(b.x - a.x, b.y - a.y);
+    const d2 = Math.hypot(c.x - b.x, c.y - b.y);
+    const r = Math.min(radius, d1 * 0.5, d2 * 0.5);
+    if (r < 2 || d1 < 1e-6 || d2 < 1e-6) {
+        out.push({ x: b.x, y: b.y });
+        return;
+    }
+    const inP = { x: b.x - (b.x - a.x) / d1 * r, y: b.y - (b.y - a.y) / d1 * r };
+    const outP = { x: b.x + (c.x - b.x) / d2 * r, y: b.y + (c.y - b.y) / d2 * r };
+    out.push(inP);
+    for (let t = 0.25; t < 0.9; t += 0.25) {
+        const mt = 1 - t;
+        out.push({
+            x: mt * mt * inP.x + 2 * mt * t * b.x + t * t * outP.x,
+            y: mt * mt * inP.y + 2 * mt * t * b.y + t * t * outP.y,
+        });
+    }
+    out.push(outP);
+}
+
+/** Round the corners of an open polyline, returning a denser polyline. */
+export function roundOpen(pts, radius) {
+    if (pts.length < 3) return pts.slice();
+    const out = [{ x: pts[0].x, y: pts[0].y }];
+    for (let i = 1; i < pts.length - 1; i++) {
+        pushRoundedCorner(out, pts[i - 1], pts[i], pts[i + 1], radius);
+    }
+    out.push({ x: pts[pts.length - 1].x, y: pts[pts.length - 1].y });
+    return out;
+}
+
+/** Round every vertex of a closed polygon; output is closed (last === first). */
+export function roundClosed(pts, radius) {
+    const n = pts.length;
+    const out = [];
+    for (let i = 0; i < n; i++) {
+        pushRoundedCorner(out, pts[(i + n - 1) % n], pts[i], pts[(i + 1) % n], radius);
+    }
+    out.push({ x: out[0].x, y: out[0].y });
+    return out;
+}
+
+/** Build a line record with cumulative arc lengths from a (possibly noisy) polyline. */
+export function buildLine(rawPts, isLoop) {
+    const pts = [rawPts[0]];
+    for (let i = 1; i < rawPts.length; i++) {
+        const prev = pts[pts.length - 1];
+        const p = rawPts[i];
+        if (Math.abs(p.x - prev.x) + Math.abs(p.y - prev.y) > 0.5) pts.push(p);
+    }
+    const cum = new Float64Array(pts.length);
+    for (let i = 1; i < pts.length; i++) {
+        cum[i] = cum[i - 1] + Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y);
+    }
+    return {
+        pts,
+        cum,
+        total: cum[pts.length - 1],
+        isLoop: !!isLoop,
+        stationDists: [],
+        stationRefs: [],
+    };
+}
+
+/**
+ * Resolve the point at arc distance `d` along a line. Writes x/y/ang into
+ * `out` and returns the segment index, which callers pass back as `hint`
+ * next frame for O(1) amortized lookups.
+ */
+export function pointAtDist(line, d, hint, out) {
+    const pts = line.pts;
+    const cum = line.cum;
+    const n = pts.length;
+    if (line.isLoop) {
+        d = ((d % line.total) + line.total) % line.total;
+    } else {
+        d = clamp(d, 0, line.total);
+    }
+    let i = clamp(hint | 0, 0, n - 2);
+    while (i > 0 && d < cum[i]) i--;
+    while (i < n - 2 && d > cum[i + 1]) i++;
+    const segLen = cum[i + 1] - cum[i];
+    const t = segLen > 0 ? (d - cum[i]) / segLen : 0;
+    const a = pts[i];
+    const b = pts[i + 1];
+    out.x = a.x + (b.x - a.x) * t;
+    out.y = a.y + (b.y - a.y) * t;
+    out.ang = Math.atan2(b.y - a.y, b.x - a.x);
+    return i;
+}
+
+/**
+ * Nearest point on a line to (x, y) using exact point-to-segment distance.
+ * Returns squared distance and the arc distance of the closest point.
+ * Only called on clicks, so the full segment scan is fine.
+ */
+export function nearestOnLine(line, x, y) {
+    const pts = line.pts;
+    const cum = line.cum;
+    let bestD2 = Infinity;
+    let bestDist = 0;
+    for (let i = 0; i + 1 < pts.length; i++) {
+        const ax = pts[i].x;
+        const ay = pts[i].y;
+        const dx = pts[i + 1].x - ax;
+        const dy = pts[i + 1].y - ay;
+        const len2 = dx * dx + dy * dy;
+        if (len2 < 1e-6) continue;
+        const t = clamp(((x - ax) * dx + (y - ay) * dy) / len2, 0, 1);
+        const px = ax + dx * t;
+        const py = ay + dy * t;
+        const ddx = x - px;
+        const ddy = y - py;
+        const d2 = ddx * ddx + ddy * ddy;
+        if (d2 < bestD2) {
+            bestD2 = d2;
+            bestDist = cum[i] + Math.sqrt(len2) * t;
+        }
+    }
+    return { d2: bestD2, dist: bestDist };
+}
+
+/** Flat-top octagon (all edges at 0/45/90/135°, matching the octilinear grammar). */
+function octagon(cx, cy, r) {
+    const pts = [];
+    for (let i = 0; i < 8; i++) {
+        const a = TAU / 16 + (i / 8) * TAU;
+        pts.push({ x: cx + Math.cos(a) * r, y: cy + Math.sin(a) * r });
+    }
+    return pts;
+}
+
+/** Point where a ray from (cx,cy) at angle `ang` exits the given rect. */
+function rayToRect(cx, cy, ang, x0, y0, x1, y1) {
+    const dx = Math.cos(ang);
+    const dy = Math.sin(ang);
+    let tMin = Infinity;
+    if (dx > 1e-9) tMin = Math.min(tMin, (x1 - cx) / dx);
+    else if (dx < -1e-9) tMin = Math.min(tMin, (x0 - cx) / dx);
+    if (dy > 1e-9) tMin = Math.min(tMin, (y1 - cy) / dy);
+    else if (dy < -1e-9) tMin = Math.min(tMin, (y0 - cy) / dy);
+    return { x: cx + dx * tMin, y: cy + dy * tMin };
+}
+
+/** Insert a station arc-distance, skipping near-duplicates, keeping sort order. */
+function insertStationDist(line, d) {
+    for (const e of line.stationDists) {
+        if (Math.abs(e - d) < 40) return;
+    }
+    line.stationDists.push(d);
+    line.stationDists.sort((a, b) => a - b);
+}
+
+function placeStationDists(line, rng, spacing) {
+    let s = spacing * (line.isLoop ? 0.3 : 0.4 + rng() * 0.4);
+    const limit = line.isLoop ? line.total - spacing * 0.45 : line.total - 36;
+    while (s < limit && line.stationDists.length < 11) {
+        insertStationDist(line, s);
+        s += spacing * (0.75 + rng() * 0.55);
+    }
+}
+
+/** Group stations of different lines that sit within 24px into interchanges. */
+function clusterStations(stations) {
+    const groups = [];
+    const R2 = 24 * 24;
+    for (let i = 0; i < stations.length; i++) {
+        for (let j = i + 1; j < stations.length; j++) {
+            const a = stations[i];
+            const b = stations[j];
+            if (a.line === b.line) continue;
+            const dx = a.x - b.x;
+            const dy = a.y - b.y;
+            if (dx * dx + dy * dy >= R2) continue;
+            if (a.group < 0 && b.group < 0) {
+                a.group = b.group = groups.length;
+                groups.push([i, j]);
+            } else if (a.group >= 0 && b.group < 0) {
+                b.group = a.group;
+                groups[a.group].push(j);
+            } else if (b.group >= 0 && a.group < 0) {
+                a.group = b.group;
+                groups[b.group].push(i);
+            } else if (a.group !== b.group) {
+                const from = groups[b.group];
+                const into = groups[a.group];
+                for (const idx of from) {
+                    stations[idx].group = a.group;
+                    into.push(idx);
+                }
+                from.length = 0;
+            }
+        }
+    }
+    return groups.filter(g => g.length > 1);
+}
+
+/**
+ * Generate a complete metro network for a w×h viewport.
+ * @param {function} rng - seeded RNG
+ * @returns {{ topology: string, lines: object[], stations: object[],
+ *             interchanges: number[][], river: object|null, cornerR: number }}
+ */
+export function generateMetroNetwork(rng, w, h) {
+    const margin = Math.min(w, h) * 0.06 + 18;
+    const cornerR = 10 + rng() * 16;
+    const topologies = ['weave', 'spokes', 'orbital', 'riverside'];
+    const topology = topologies[Math.floor(rng() * topologies.length)];
+    const lines = [];
+    let river = null;
+
+    const addOpen = (raw) => lines.push(buildLine(roundOpen(raw, cornerR), false));
+    const addClosed = (raw) => lines.push(buildLine(roundClosed(raw, cornerR), true));
+
+    // Diameter line through (cx, cy) at one of the four octilinear angles.
+    // Returns the arc distance of the hub so a station can be pinned there.
+    const addDiameter = (cx, cy, ang) => {
+        const a = rayToRect(cx, cy, ang, margin, margin, w - margin, h - margin);
+        const b = rayToRect(cx, cy, ang + Math.PI, margin, margin, w - margin, h - margin);
+        const ln = buildLine([a, { x: cx, y: cy }, b], false);
+        lines.push(ln);
+        return Math.hypot(cx - a.x, cy - a.y);
+    };
+
+    if (topology === 'weave') {
+        const nH = 1 + Math.floor(rng() * 3);
+        const nV = 1 + Math.floor(rng() * (nH > 2 ? 2 : 3));
+        for (let i = 0; i < nH; i++) {
+            const sy = h * (0.14 + 0.72 * ((i + 0.2 + rng() * 0.6) / nH));
+            const ey = clamp(sy + (rng() - 0.5) * h * 0.5, margin, h - margin);
+            const ltr = rng() < 0.5;
+            addOpen(octilinearPath(rng, ltr ? margin : w - margin, sy, ltr ? w - margin : margin, ey,
+                1 + Math.floor(rng() * 3), margin, w - margin, margin, h - margin));
+        }
+        for (let i = 0; i < nV; i++) {
+            const sx = w * (0.12 + 0.76 * ((i + 0.2 + rng() * 0.6) / nV));
+            const ex = clamp(sx + (rng() - 0.5) * w * 0.4, margin, w - margin);
+            const ttb = rng() < 0.5;
+            addOpen(octilinearPath(rng, sx, ttb ? margin : h - margin, ex, ttb ? h - margin : margin,
+                1 + Math.floor(rng() * 3), margin, w - margin, margin, h - margin));
+        }
+        if (rng() < 0.3) {
+            // One bold corner-to-corner diagonal
+            const flip = rng() < 0.5;
+            addOpen(octilinearPath(rng, margin, flip ? h - margin : margin, w - margin, flip ? margin : h - margin,
+                2 + Math.floor(rng() * 2), margin, w - margin, margin, h - margin));
+        }
+    } else if (topology === 'spokes') {
+        const cx = w * (0.38 + rng() * 0.24);
+        const cy = h * (0.38 + rng() * 0.24);
+        const angles = [0, TAU / 8, TAU / 4, TAU * 3 / 8];
+        // Fisher-Yates with the seeded rng
+        for (let i = angles.length - 1; i > 0; i--) {
+            const j = Math.floor(rng() * (i + 1));
+            const t = angles[i]; angles[i] = angles[j]; angles[j] = t;
+        }
+        const count = 3 + (rng() < 0.55 ? 1 : 0);
+        const hubDists = [];
+        for (let i = 0; i < count; i++) hubDists.push(addDiameter(cx, cy, angles[i]));
+        if (rng() < 0.7) {
+            addClosed(octagon(cx, cy, Math.min(w, h) * (0.2 + rng() * 0.13)));
+        }
+        // Pin a station on every diameter at the hub → clustered mega-interchange
+        for (let i = 0; i < count; i++) insertStationDist(lines[i], hubDists[i]);
+    } else if (topology === 'orbital') {
+        const cx = w * (0.42 + rng() * 0.16);
+        const cy = h * (0.42 + rng() * 0.16);
+        const m = Math.min(w, h);
+        addClosed(octagon(cx, cy, m * (0.13 + rng() * 0.05)));
+        addClosed(octagon(cx, cy, m * (0.3 + rng() * 0.09)));
+        const angles = [0, TAU / 8, TAU / 4, TAU * 3 / 8];
+        const start = Math.floor(rng() * 4);
+        const count = 2 + (rng() < 0.5 ? 1 : 0);
+        for (let i = 0; i < count; i++) {
+            const ringCount = lines.length;
+            const hubDist = addDiameter(cx, cy, angles[(start + i) % 4]);
+            insertStationDist(lines[ringCount], hubDist);
+        }
+    } else { // riverside
+        const riverY = h * (0.32 + rng() * 0.36);
+        const riverRaw = octilinearPath(rng, -40, riverY, w + 40, clamp(riverY + (rng() - 0.5) * h * 0.35, h * 0.2, h * 0.8),
+            2 + Math.floor(rng() * 3), -40, w + 40, h * 0.16, h * 0.84);
+        river = { pts: roundOpen(riverRaw, cornerR * 2.4), width: 18 + rng() * 24 };
+        const banks = 2 + (rng() < 0.4 ? 1 : 0);
+        for (let i = 0; i < banks; i++) {
+            const above = i % 2 === 0;
+            const off = 50 + rng() * h * 0.18;
+            const sy = clamp(riverY + (above ? -off : off), margin, h - margin);
+            const yLo = above ? margin : clamp(riverY + 34, margin, h - margin);
+            const yHi = above ? clamp(riverY - 34, margin, h - margin) : h - margin;
+            addOpen(octilinearPath(rng, margin, sy, w - margin, clamp(sy + (rng() - 0.5) * h * 0.3, yLo, yHi),
+                1 + Math.floor(rng() * 3), margin, w - margin, Math.min(yLo, yHi), Math.max(yLo, yHi)));
+        }
+        const crossings = 1 + Math.floor(rng() * 3);
+        for (let i = 0; i < crossings; i++) {
+            const sx = w * (0.15 + 0.7 * ((i + rng() * 0.8) / crossings));
+            addOpen(octilinearPath(rng, sx, margin, clamp(sx + (rng() - 0.5) * w * 0.3, margin, w - margin), h - margin,
+                1 + Math.floor(rng() * 2), margin, w - margin, margin, h - margin));
+        }
+    }
+
+    // ── Stations ──
+    const spacing = 95 + rng() * 75;
+    const stations = [];
+    const scratch = { x: 0, y: 0, ang: 0 };
+    for (let li = 0; li < lines.length; li++) {
+        const ln = lines[li];
+        placeStationDists(ln, rng, spacing);
+        let seg = 0;
+        for (const d of ln.stationDists) {
+            seg = pointAtDist(ln, d, seg, scratch);
+            ln.stationRefs.push(stations.length);
+            stations.push({
+                x: scratch.x,
+                y: scratch.y,
+                ang: scratch.ang,
+                line: li,
+                dist: d,
+                group: -1,
+                pax: 0,
+                maxPax: 4,
+            });
+        }
+    }
+    const interchanges = clusterStations(stations);
+
+    return { topology, lines, stations, interchanges, river, cornerR };
+}

--- a/js/metro_transit_effects.js
+++ b/js/metro_transit_effects.js
@@ -1,0 +1,564 @@
+/**
+ * @file metro_transit_effects.js
+ * @description Interactive effect: a living schematic metro map. A seeded
+ * octilinear transit network (see metro_map_generator.js) is pre-rendered once
+ * to an offscreen canvas; glowing trains then run the lines in real time,
+ * easing into stations, dwelling with blinking doors, and collecting the tiny
+ * passengers that accumulate on platforms.
+ *
+ * Seed-driven variation:
+ *  - 4 network topologies: weave, spokes (hub + optional ring), orbital
+ *    (concentric rings + diameters), riverside (banks bridged across a river)
+ *  - 2-7 lines with distinct hues spread around a palette-derived base, in
+ *    neon / classic / pastel colorways
+ *  - 4 station styles (ringed disc, white dot, perpendicular tick, square),
+ *    line width, map opacity, corner radius, station spacing
+ *  - train fleet size, car count (1-3), speed, dwell time; rare dashed
+ *    "under construction" line
+ *  - optional river band; interchange clusters drawn as connected white discs
+ *
+ * Interaction: the cursor highlights the nearest station (pulse ring + roundel
+ * badge, waiting passengers perk up); clicking dispatches a bright express
+ * train onto the nearest line from the click point.
+ *
+ * Performance: the entire static map (river, casings, line cores, termini,
+ * interchange connectors, stations) is rasterized once per universe into an
+ * offscreen canvas and blitted per frame; per-frame work is only trains
+ * (arc-length lookup with cached segment hints), capped pooled pings, and one
+ * batched passenger fill.
+ */
+
+import { generateMetroNetwork, pointAtDist, nearestOnLine } from './metro_map_generator.js';
+
+const TAU = Math.PI * 2;
+
+function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+/** Axis-aligned capsule path centered on the origin (call within a rotated ctx). */
+function capsulePath(ctx, halfLen, halfWid) {
+    const hl = Math.max(halfLen, halfWid + 0.1);
+    ctx.beginPath();
+    ctx.moveTo(-hl + halfWid, -halfWid);
+    ctx.lineTo(hl - halfWid, -halfWid);
+    ctx.arc(hl - halfWid, 0, halfWid, -Math.PI / 2, Math.PI / 2);
+    ctx.lineTo(-hl + halfWid, halfWid);
+    ctx.arc(-hl + halfWid, 0, halfWid, Math.PI / 2, Math.PI * 1.5);
+    ctx.closePath();
+}
+
+function strokePolyline(g, pts) {
+    g.beginPath();
+    g.moveTo(pts[0].x, pts[0].y);
+    for (let i = 1; i < pts.length; i++) g.lineTo(pts[i].x, pts[i].y);
+    g.stroke();
+}
+
+export class MetroTransit {
+    constructor() {
+        this._net = null;
+        this._trains = [];
+        this._pings = [];
+        this._pingPool = [];
+        this._tick = 0;
+        this._mapCanvas = null;
+        this._mapDirty = true;
+        this._genW = 1;
+        this._genH = 1;
+        this._hoverStation = -1;
+        this._wasClicking = false;
+        this._expressCount = 0;
+        this._lcg = 1;
+        this._pt = { x: 0, y: 0, ang: 0 }; // scratch for pointAtDist
+    }
+
+    /** Deterministic runtime RNG, reseeded from the universe seed in configure(). */
+    _rand() {
+        this._lcg = (Math.imul(this._lcg, 1664525) + 1013904223) >>> 0;
+        return this._lcg / 4294967296;
+    }
+
+    configure(rng, palette) {
+        this._tick = 0;
+        this._genW = Math.max(480, window.innerWidth);
+        this._genH = Math.max(360, window.innerHeight);
+        this._lcg = ((rng() * 4294967296) >>> 0) || 1;
+
+        this._net = generateMetroNetwork(rng, this._genW, this._genH);
+        const lines = this._net.lines;
+
+        // ── Colorway: one distinct hue per line around a palette-derived base ──
+        const styleRoll = rng();
+        const sat = styleRoll < 0.33 ? 95 : styleRoll < 0.7 ? 76 : 56; // neon / classic / pastel
+        const light = styleRoll < 0.33 ? 58 : styleRoll < 0.7 ? 52 : 68;
+        const baseHue = palette && palette.length > 0
+            ? palette[Math.floor(rng() * palette.length)].h
+            : rng() * 360;
+        const hueStep = 360 / lines.length;
+        for (let i = 0; i < lines.length; i++) {
+            const ln = lines[i];
+            ln.hue = (baseHue + i * hueStep + (rng() - 0.5) * 24 + 360) % 360;
+            ln.sat = sat;
+            ln.light = light;
+            ln.dashed = false;
+        }
+        if (lines.length > 2 && rng() < 0.14) {
+            lines[Math.floor(rng() * lines.length)].dashed = true; // under construction
+        }
+
+        this._lineWidth = 2.5 + rng() * 2;
+        this._stationR = this._lineWidth * 1.25 + 1.4;
+        this._stationStyle = Math.floor(rng() * 4); // 0 ring-disc, 1 dot, 2 tick, 3 square
+        this._mapAlpha = 0.55 + rng() * 0.3;
+        this._riverHue = 185 + rng() * 50;
+
+        // ── Trains ──
+        this._trains.length = 0;
+        this._expressCount = 0;
+        this._speedBase = 0.7 + rng() * 0.8;
+        this._dwellTicks = 26 + Math.floor(rng() * 30);
+        this._carCount = 1 + Math.floor(rng() * 3);
+        this._carLen = 13 + rng() * 7;
+        this._carGap = 3;
+        for (let i = 0; i < lines.length; i++) {
+            const ln = lines[i];
+            const n = 1 + (ln.total > 1100 ? 1 : 0) + (rng() < 0.3 ? 1 : 0);
+            for (let k = 0; k < n; k++) {
+                this._spawnTrain(ln, ln.total * ((k + rng() * 0.6) / n),
+                    rng() < 0.5 ? 1 : -1, this._speedBase * (0.85 + rng() * 0.3), false);
+            }
+        }
+
+        // ── Passengers ──
+        this._paxRate = 0.0012 + rng() * 0.0035;
+        for (const st of this._net.stations) {
+            st.maxPax = 3 + Math.floor(rng() * 5);
+            st.pax = rng() < 0.5 ? Math.floor(rng() * 3) : 0;
+        }
+
+        this._pings.length = 0;
+        this._pingPool.length = 0;
+        this._hoverStation = -1;
+        this._wasClicking = false;
+        this._mapDirty = true;
+    }
+
+    _spawnTrain(line, dist, dir, speed, express) {
+        const t = { line, dist, dir, speed, seg: 0, dwell: 0, stopIdx: -1, express };
+        this._syncNextStop(t);
+        this._trains.push(t);
+        return t;
+    }
+
+    /** Point stopIdx at the first station strictly ahead in the travel direction. */
+    _syncNextStop(t) {
+        t.stopIdx = -1;
+        if (t.express) return; // expresses sail through
+        const ds = t.line.stationDists;
+        if (ds.length === 0) return;
+        if (t.dir > 0) {
+            for (let i = 0; i < ds.length; i++) {
+                if (ds[i] > t.dist + 1) { t.stopIdx = i; return; }
+            }
+            if (t.line.isLoop) t.stopIdx = 0;
+        } else {
+            for (let i = ds.length - 1; i >= 0; i--) {
+                if (ds[i] < t.dist - 1) { t.stopIdx = i; return; }
+            }
+            if (t.line.isLoop) t.stopIdx = ds.length - 1;
+        }
+    }
+
+    _board(t) {
+        if (t.stopIdx < 0) return;
+        const st = this._net.stations[t.line.stationRefs[t.stopIdx]];
+        if (st && st.pax > 0) {
+            st.pax = 0;
+            this._spawnPing(st.x, st.y, 18, t.line.hue, 0.45);
+        }
+    }
+
+    _spawnPing(x, y, maxR, hue, alpha) {
+        if (this._pings.length >= 14) return;
+        const p = this._pingPool.length > 0 ? this._pingPool.pop() : {};
+        p.x = x; p.y = y; p.r = 2; p.maxR = maxR;
+        p.hue = hue; p.alpha = alpha; p.spd = 1 + maxR / 30;
+        this._pings.push(p);
+    }
+
+    _dispatchExpress(nx, ny) {
+        if (this._expressCount >= 4 || !this._net) return;
+        const lines = this._net.lines;
+        let bestLine = -1;
+        let bestD2 = 150 * 150;
+        let bestDist = 0;
+        for (let i = 0; i < lines.length; i++) {
+            const near = nearestOnLine(lines[i], nx, ny);
+            if (near.d2 < bestD2) {
+                bestD2 = near.d2;
+                bestLine = i;
+                bestDist = near.dist;
+            }
+        }
+        if (bestLine < 0) return;
+        const ln = lines[bestLine];
+        const t = this._spawnTrain(ln, bestDist, this._rand() < 0.5 ? -1 : 1,
+            this._speedBase * 2.4, true);
+        this._expressCount++;
+        t.seg = pointAtDist(ln, t.dist, 0, this._pt);
+        this._spawnPing(this._pt.x, this._pt.y, 36, ln.hue, 0.6);
+    }
+
+    update(mx, my, isClicking) {
+        this._tick++;
+        if (!this._net) return;
+
+        // Mouse → network space (the map stretches with the window after resize)
+        const nx = mx * (this._genW / Math.max(1, window.innerWidth));
+        const ny = my * (this._genH / Math.max(1, window.innerHeight));
+
+        // ── Hover station ──
+        const stations = this._net.stations;
+        let best = -1;
+        let bestD = 80 * 80;
+        for (let i = 0; i < stations.length; i++) {
+            const dx = stations[i].x - nx;
+            const dy = stations[i].y - ny;
+            const d = dx * dx + dy * dy;
+            if (d < bestD) { bestD = d; best = i; }
+        }
+        this._hoverStation = best;
+        if (best >= 0 && this._tick % 36 === 0) {
+            const st = stations[best];
+            this._spawnPing(st.x, st.y, 26, this._net.lines[st.line].hue, 0.3);
+        }
+
+        // ── Click: dispatch an express from the nearest line ──
+        const clicked = isClicking && !this._wasClicking;
+        this._wasClicking = isClicking;
+        if (clicked) this._dispatchExpress(nx, ny);
+
+        // ── Passengers trickle onto platforms ──
+        if ((this._tick & 1) === 0) {
+            for (let i = 0; i < stations.length; i++) {
+                const st = stations[i];
+                if (st.pax < st.maxPax && this._rand() < this._paxRate * 2) st.pax++;
+            }
+        }
+
+        // ── Trains ──
+        for (let i = this._trains.length - 1; i >= 0; i--) {
+            const t = this._trains[i];
+            if (t.dwell > 0) {
+                t.dwell--;
+                if (t.dwell === 0) this._syncNextStop(t);
+                continue;
+            }
+            let sp = t.speed;
+            if (t.stopIdx >= 0) {
+                const ds = t.line.stationDists;
+                let gap = t.dir > 0 ? ds[t.stopIdx] - t.dist : t.dist - ds[t.stopIdx];
+                if (gap < 0 && t.line.isLoop) gap += t.line.total;
+                if (gap < 48) sp *= 0.3 + 0.7 * (gap / 48); // ease into the platform
+                if (gap <= sp) {
+                    t.dist = ds[t.stopIdx];
+                    t.dwell = this._dwellTicks;
+                    this._board(t);
+                    continue;
+                }
+            }
+            t.dist += sp * t.dir;
+            if (t.line.isLoop) {
+                if (t.dist >= t.line.total) t.dist -= t.line.total;
+                else if (t.dist < 0) t.dist += t.line.total;
+            } else if (t.dist >= t.line.total || t.dist <= 0) {
+                t.dist = clamp(t.dist, 0, t.line.total);
+                if (t.express) {
+                    t.seg = pointAtDist(t.line, t.dist, t.seg, this._pt);
+                    this._spawnPing(this._pt.x, this._pt.y, 40, t.line.hue, 0.5);
+                    this._trains[i] = this._trains[this._trains.length - 1];
+                    this._trains.pop();
+                    this._expressCount--;
+                    continue;
+                }
+                t.dir *= -1;
+                t.dwell = this._dwellTicks; // terminus layover
+                this._syncNextStop(t);
+            }
+        }
+
+        // ── Pings ──
+        for (let i = this._pings.length - 1; i >= 0; i--) {
+            const p = this._pings[i];
+            p.r += p.spd;
+            p.alpha *= 0.94;
+            if (p.r > p.maxR || p.alpha < 0.02) {
+                this._pingPool.push(p);
+                this._pings[i] = this._pings[this._pings.length - 1];
+                this._pings.pop();
+            }
+        }
+    }
+
+    draw(ctx, system) {
+        if (!this._net) return;
+        if (this._mapDirty) this._prerender();
+
+        const q = system.qualityScale || 1;
+        const sx = system.width / this._genW;
+        const sy = system.height / this._genH;
+
+        ctx.save();
+        ctx.globalCompositeOperation = 'source-over';
+        if (Math.abs(sx - 1) > 0.001 || Math.abs(sy - 1) > 0.001) ctx.scale(sx, sy);
+
+        ctx.globalAlpha = this._mapAlpha;
+        ctx.drawImage(this._mapCanvas, 0, 0);
+        ctx.globalAlpha = 1;
+
+        if (q >= 0.5) this._drawPassengers(ctx);
+        this._drawHover(ctx);
+        this._drawTrains(ctx, q);
+
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.lineWidth = 1.5;
+        for (const p of this._pings) {
+            ctx.strokeStyle = `hsla(${p.hue}, 90%, 65%, ${p.alpha})`;
+            ctx.beginPath();
+            ctx.arc(p.x, p.y, p.r, 0, TAU);
+            ctx.stroke();
+        }
+        ctx.restore();
+    }
+
+    _drawPassengers(ctx) {
+        const stations = this._net.stations;
+        ctx.fillStyle = 'rgba(255, 244, 214, 0.5)';
+        ctx.beginPath();
+        for (let i = 0; i < stations.length; i++) {
+            if (i === this._hoverStation) continue;
+            this._addPaxRects(ctx, stations[i], 0);
+        }
+        ctx.fill();
+        // Hovered platform: passengers perk up (brighter, jiggling)
+        if (this._hoverStation >= 0) {
+            ctx.fillStyle = 'rgba(255, 250, 235, 0.85)';
+            ctx.beginPath();
+            this._addPaxRects(ctx, stations[this._hoverStation], this._tick);
+            ctx.fill();
+        }
+    }
+
+    _addPaxRects(ctx, st, jiggleTick) {
+        const n = st.pax | 0;
+        if (n === 0) return;
+        const px = Math.cos(st.ang + Math.PI / 2);
+        const py = Math.sin(st.ang + Math.PI / 2);
+        const ax = Math.cos(st.ang);
+        const ay = Math.sin(st.ang);
+        for (let k = 0; k < n; k++) {
+            const off = 8 + (k >> 1) * 4.5;
+            const side = (k & 1) === 0 ? 1 : -1;
+            const along = ((k * 53) % 9) - 4;
+            const jig = jiggleTick > 0 ? Math.sin(jiggleTick * 0.22 + k * 1.7) * 1.5 : 0;
+            const x = st.x + px * off * side + ax * (along + jig);
+            const y = st.y + py * off * side + ay * (along + jig);
+            ctx.rect(x - 1, y - 1, 2, 2);
+        }
+    }
+
+    _drawHover(ctx) {
+        if (this._hoverStation < 0) return;
+        const st = this._net.stations[this._hoverStation];
+        const hue = this._net.lines[st.line].hue;
+        const pulse = 0.5 + 0.5 * Math.sin(this._tick * 0.12);
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.strokeStyle = `hsla(${hue}, 90%, 70%, ${0.2 + pulse * 0.3})`;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(st.x, st.y, this._stationR * (2 + pulse * 0.7), 0, TAU);
+        ctx.stroke();
+        // Mini roundel badge above the station
+        const by = st.y - this._stationR - 14;
+        ctx.strokeStyle = `hsla(${hue}, 85%, 62%, 0.85)`;
+        ctx.lineWidth = 2.5;
+        ctx.beginPath();
+        ctx.arc(st.x, by, 5.5, 0, TAU);
+        ctx.stroke();
+        ctx.fillStyle = 'rgba(245, 245, 255, 0.9)';
+        ctx.fillRect(st.x - 8.5, by - 1.5, 17, 3);
+        ctx.restore();
+    }
+
+    _drawTrains(ctx, q) {
+        ctx.save();
+        ctx.globalCompositeOperation = 'lighter';
+        const pt = this._pt;
+        const halfWid = (this._lineWidth + 2.6) / 2;
+        const halfLen = this._carLen / 2;
+        const step = this._carLen + this._carGap;
+        for (const t of this._trains) {
+            const ln = t.line;
+            const cars = t.express ? this._carCount + 1 : this._carCount;
+            const doors = t.dwell > 0 && t.dwell % 14 < 7;
+            let seg = t.seg;
+            for (let c = 0; c < cars; c++) {
+                const d = t.dist - t.dir * c * step;
+                if (!ln.isLoop && (d < 0 || d > ln.total)) continue;
+                seg = pointAtDist(ln, d, seg, pt);
+                if (c === 0) t.seg = seg;
+                ctx.save();
+                ctx.translate(pt.x, pt.y);
+                ctx.rotate(pt.ang);
+                if (q >= 0.5) {
+                    ctx.fillStyle = `hsla(${ln.hue}, 95%, 65%, 0.1)`;
+                    capsulePath(ctx, halfLen * 1.7, halfWid * 2.3);
+                    ctx.fill();
+                }
+                ctx.fillStyle = `hsla(${ln.hue}, ${ln.sat}%, ${t.express ? 80 : 66}%, 0.95)`;
+                capsulePath(ctx, halfLen, halfWid);
+                ctx.fill();
+                if (t.express) {
+                    ctx.fillStyle = 'rgba(255, 255, 255, 0.7)';
+                    capsulePath(ctx, halfLen * 0.55, halfWid * 0.3);
+                    ctx.fill();
+                } else if (doors) {
+                    ctx.strokeStyle = 'rgba(255, 255, 255, 0.75)';
+                    ctx.lineWidth = 1;
+                    capsulePath(ctx, halfLen, halfWid);
+                    ctx.stroke();
+                }
+                if (c === 0 && t.dwell === 0) {
+                    ctx.fillStyle = 'rgba(255, 255, 230, 0.8)';
+                    ctx.beginPath();
+                    ctx.arc(t.dir > 0 ? halfLen + 3 : -halfLen - 3, 0, 1.4, 0, TAU);
+                    ctx.fill();
+                }
+                ctx.restore();
+            }
+        }
+        ctx.restore();
+    }
+
+    /** Rasterize the static map (river, lines, termini, interchanges, stations). */
+    _prerender() {
+        if (!this._mapCanvas) this._mapCanvas = document.createElement('canvas');
+        const c = this._mapCanvas;
+        c.width = this._genW;
+        c.height = this._genH;
+        const g = c.getContext('2d');
+        g.lineCap = 'round';
+        g.lineJoin = 'round';
+
+        const net = this._net;
+        const lw = this._lineWidth;
+        const sr = this._stationR;
+
+        if (net.river) {
+            g.strokeStyle = `hsla(${this._riverHue}, 60%, 45%, 0.16)`;
+            g.lineWidth = net.river.width;
+            strokePolyline(g, net.river.pts);
+            g.strokeStyle = `hsla(${this._riverHue}, 70%, 60%, 0.1)`;
+            g.lineWidth = net.river.width * 0.5;
+            strokePolyline(g, net.river.pts);
+        }
+
+        // Dark casings first, then all cores: crossings read as layered tubes
+        g.strokeStyle = 'rgba(0, 0, 0, 0.45)';
+        g.lineWidth = lw + 4;
+        for (const ln of net.lines) strokePolyline(g, ln.pts);
+        for (const ln of net.lines) {
+            g.strokeStyle = `hsla(${ln.hue}, ${ln.sat}%, ${ln.light}%, 0.9)`;
+            g.lineWidth = lw;
+            if (ln.dashed) g.setLineDash([lw * 3, lw * 2.2]);
+            strokePolyline(g, ln.pts);
+            if (ln.dashed) g.setLineDash([]);
+        }
+
+        // Terminus bars on open lines
+        g.lineWidth = lw * 0.9;
+        for (const ln of net.lines) {
+            if (ln.isLoop) continue;
+            g.strokeStyle = `hsla(${ln.hue}, ${ln.sat}%, ${Math.min(90, ln.light + 22)}%, 0.95)`;
+            this._terminusBar(g, ln.pts[0], ln.pts[1], sr * 1.9);
+            this._terminusBar(g, ln.pts[ln.pts.length - 1], ln.pts[ln.pts.length - 2], sr * 1.9);
+        }
+
+        // Interchange connectors: black casing + white capsule between members
+        for (const group of net.interchanges) {
+            for (let pass = 0; pass < 2; pass++) {
+                g.strokeStyle = pass === 0 ? 'rgba(5, 5, 12, 0.7)' : 'rgba(245, 245, 255, 0.85)';
+                g.lineWidth = pass === 0 ? sr * 2.4 : sr * 1.6;
+                g.beginPath();
+                g.moveTo(net.stations[group[0]].x, net.stations[group[0]].y);
+                for (let m = 1; m < group.length; m++) {
+                    g.lineTo(net.stations[group[m]].x, net.stations[group[m]].y);
+                }
+                g.stroke();
+            }
+        }
+
+        for (const st of net.stations) this._drawStation(g, st);
+
+        this._mapDirty = false;
+    }
+
+    _terminusBar(g, end, prev, len) {
+        const ang = Math.atan2(end.y - prev.y, end.x - prev.x) + Math.PI / 2;
+        const dx = Math.cos(ang) * len;
+        const dy = Math.sin(ang) * len;
+        g.beginPath();
+        g.moveTo(end.x + dx, end.y + dy);
+        g.lineTo(end.x - dx, end.y - dy);
+        g.stroke();
+    }
+
+    _drawStation(g, st) {
+        const ln = this._net.lines[st.line];
+        const sr = this._stationR;
+        if (st.group >= 0) {
+            // Interchange member: white-ringed disc regardless of style
+            g.fillStyle = 'rgba(8, 8, 16, 0.9)';
+            g.strokeStyle = 'rgba(245, 245, 255, 0.9)';
+            g.lineWidth = 1.8;
+            g.beginPath();
+            g.arc(st.x, st.y, sr * 1.15, 0, TAU);
+            g.fill();
+            g.stroke();
+            return;
+        }
+        const color = `hsla(${ln.hue}, ${ln.sat}%, ${Math.min(88, ln.light + 18)}%, 0.95)`;
+        if (this._stationStyle === 1) {
+            g.fillStyle = 'rgba(240, 240, 250, 0.9)';
+            g.beginPath();
+            g.arc(st.x, st.y, sr * 0.7, 0, TAU);
+            g.fill();
+        } else if (this._stationStyle === 2) {
+            // Perpendicular tick, London-style
+            const dx = Math.cos(st.ang + Math.PI / 2) * sr * 1.9;
+            const dy = Math.sin(st.ang + Math.PI / 2) * sr * 1.9;
+            g.strokeStyle = color;
+            g.lineWidth = this._lineWidth * 0.8;
+            g.beginPath();
+            g.moveTo(st.x, st.y);
+            g.lineTo(st.x + dx, st.y + dy);
+            g.stroke();
+        } else if (this._stationStyle === 3) {
+            g.fillStyle = 'rgba(8, 8, 16, 0.9)';
+            g.strokeStyle = color;
+            g.lineWidth = 1.5;
+            g.beginPath();
+            g.rect(st.x - sr * 0.85, st.y - sr * 0.85, sr * 1.7, sr * 1.7);
+            g.fill();
+            g.stroke();
+        } else {
+            g.fillStyle = 'rgba(8, 8, 16, 0.9)';
+            g.strokeStyle = color;
+            g.lineWidth = 1.6;
+            g.beginPath();
+            g.arc(st.x, st.y, sr * 0.9, 0, TAU);
+            g.fill();
+            g.stroke();
+        }
+    }
+}

--- a/js/midi_input.js
+++ b/js/midi_input.js
@@ -1,0 +1,100 @@
+/**
+ * @file midi_input.js
+ * @description Web MIDI input: plug in a hardware controller and play the
+ * universe like an instrument. Knobs/faders (CC messages) are auto-learned
+ * into 8 slots in the order you first touch them; notes strike shockwaves
+ * positioned by pitch and sized by velocity; the mod wheel leans on warp.
+ *
+ * Consumers read per-frame state (background.js applies it like micReactive):
+ *  - knobs[0..7]  : 0..1, NaN until that slot is learned
+ *  - modWheel     : 0..1
+ *  - pitchBend    : -1..1
+ *  - drainNotes() : note-on events since last frame [{ note, velocity }]
+ *
+ * Follows the permission-gated input singleton pattern (mic/camera/speech):
+ * nothing is requested until the user activates it from the toolbar.
+ */
+
+export const midiInput = {
+    supported: typeof navigator !== 'undefined' && 'requestMIDIAccess' in navigator,
+    active: false,
+    deviceName: '',
+    knobs: new Float32Array(8).fill(NaN),
+    modWheel: 0,
+    pitchBend: 0,
+
+    _access: null,
+    _ccSlots: new Map(), // cc number -> knob slot, learned in touch order
+    _notes: [],
+
+    async activate() {
+        if (!this.supported) throw new Error('Web MIDI not supported');
+        if (this.active) return;
+        this._access = await navigator.requestMIDIAccess({ sysex: false });
+        this._attachAll();
+        this._access.onstatechange = () => this._attachAll();
+        this.active = true;
+    },
+
+    deactivate() {
+        if (this._access) {
+            for (const input of this._access.inputs.values()) input.onmidimessage = null;
+            this._access.onstatechange = null;
+            this._access = null;
+        }
+        this.active = false;
+        this.deviceName = '';
+        this.knobs.fill(NaN);
+        this._ccSlots.clear();
+        this._notes.length = 0;
+        this.modWheel = 0;
+        this.pitchBend = 0;
+    },
+
+    _attachAll() {
+        if (!this._access) return;
+        const names = [];
+        for (const input of this._access.inputs.values()) {
+            input.onmidimessage = (e) => this._onMessage(e);
+            names.push(input.name || 'MIDI device');
+        }
+        this.deviceName = names.join(', ');
+    },
+
+    _onMessage(e) {
+        const data = e.data;
+        if (!data || data.length < 2) return;
+        const type = data[0] & 0xF0;
+        if (type === 0x90 && data[2] > 0) {
+            // Note on
+            if (this._notes.length < 32) {
+                this._notes.push({ note: data[1], velocity: data[2] / 127 });
+            }
+        } else if (type === 0xB0) {
+            const cc = data[1];
+            const value = data[2] / 127;
+            if (cc === 1) {
+                this.modWheel = value;
+                return;
+            }
+            // Auto-learn: first 8 distinct CCs become knob slots
+            let slot = this._ccSlots.get(cc);
+            if (slot === undefined && this._ccSlots.size < 8) {
+                slot = this._ccSlots.size;
+                this._ccSlots.set(cc, slot);
+            }
+            if (slot !== undefined) this.knobs[slot] = value;
+        } else if (type === 0xE0 && data.length >= 3) {
+            // Pitch bend: 14-bit centered on 8192
+            this.pitchBend = ((data[2] << 7) | data[1]) / 8192 - 1;
+        }
+    },
+
+    /** Return and clear note-on events accumulated since the last frame. */
+    drainNotes() {
+        if (this._notes.length === 0) return this._notes;
+        const out = this._notes.slice();
+        this._notes.length = 0;
+        return out;
+    },
+};

--- a/js/particle_engine.js
+++ b/js/particle_engine.js
@@ -1,0 +1,324 @@
+/**
+ * @file particle_engine.js
+ * @description In-house particle engine replacing the particles.js 2.0.0 CDN
+ * dependency. Exposes the exact pJS-shaped API surface the rest of the
+ * codebase consumes (pJS.particles.*, pJS.canvas.*, pJS.fn.*), so the
+ * simulation, powers, mutators, anomalies, and cataclysms run unchanged —
+ * while fixing what the old library got wrong:
+ *
+ *  - particlesDraw() no longer secretly runs a second physics update per
+ *    frame (particles.js v2 called particlesUpdate() inside particlesDraw(),
+ *    doubling motion). update and draw are now honestly separate; the
+ *    integration factor matches the old *net* displacement so the tuned
+ *    universe speeds feel identical.
+ *  - move.trail actually works. The old config asked for trails that
+ *    particles.js v2 never supported (its internal clearRect wiped the
+ *    fade fill every frame). Trails now fade via destination-out, so they
+ *    composite correctly over the background instead of smearing black.
+ *  - DPR-aware rendering: logic stays in CSS pixels (matching mouse
+ *    coordinates everywhere), the backing store scales by devicePixelRatio.
+ *    The old retina path put particles in device pixels while the app's
+ *    powers aimed in CSS pixels, so interactions missed on hi-DPI screens.
+ *  - pushParticles() returns the created particles. Callers (safePush)
+ *    always expected an array; the old library returned undefined, so
+ *    spawned particles from quasars/geysers/nurseries were never tagged.
+ *
+ * No DOM strings, no innerHTML — CSP/Trusted Types safe.
+ */
+
+import { mouse } from './state.js';
+
+const TAU = Math.PI * 2;
+
+function hexToRgb(hex) {
+    const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex || '');
+    return m
+        ? { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) }
+        : { r: 255, g: 255, b: 255 };
+}
+
+export function createParticleEngine(containerId, config) {
+    const container = document.getElementById(containerId);
+    const el = document.createElement('canvas');
+    el.style.width = '100%';
+    el.style.height = '100%';
+    el.style.display = 'block';
+    if (container) container.appendChild(el);
+    const ctx = el.getContext('2d');
+
+    // Deep-copy config so per-universe mutation never corrupts baseConfig
+    const particles = structuredClone(config.particles);
+    if (particles.number.value_max === undefined) particles.number.value_max = 400;
+    if (!particles.line_linked.distance) particles.line_linked.distance = 150;
+    if (particles.line_linked.opacity === undefined) particles.line_linked.opacity = 0.4;
+    if (!particles.move.attract.rotateX) particles.move.attract.rotateX = 600;
+    if (!particles.move.attract.rotateY) particles.move.attract.rotateY = 1200;
+    if (!particles.move.trail.length) particles.move.trail.length = 10;
+    particles.array = [];
+
+    const interactivity = structuredClone(config.interactivity || {});
+    const bubble = interactivity.modes && interactivity.modes.bubble;
+    const bubbleOn = !!(interactivity.events && interactivity.events.onhover
+        && interactivity.events.onhover.enable && interactivity.events.onhover.mode === 'bubble');
+
+    const pJS = {
+        canvas: { el, ctx, w: 0, h: 0, dpr: 1 },
+        particles,
+        fn: {},
+    };
+
+    const pool = [];
+
+    function resize() {
+        const dpr = Math.min(2, window.devicePixelRatio || 1);
+        pJS.canvas.w = window.innerWidth;
+        pJS.canvas.h = window.innerHeight;
+        pJS.canvas.dpr = dpr;
+        el.width = Math.max(1, Math.round(pJS.canvas.w * dpr));
+        el.height = Math.max(1, Math.round(pJS.canvas.h * dpr));
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function createParticle(x, y) {
+        const p = pool.length > 0 ? pool.pop() : {};
+        p.x = x !== undefined ? x : Math.random() * pJS.canvas.w;
+        p.y = y !== undefined ? y : Math.random() * pJS.canvas.h;
+        p.vx = Math.random() - 0.5;
+        p.vy = Math.random() - 0.5;
+        const size = particles.size;
+        p.radius = Math.max(0.6, (size.random ? Math.random() : 1) * size.value);
+        p.radius_initial = p.radius;
+        p.opacity = { value: particles.opacity.random ? Math.random() * particles.opacity.value : particles.opacity.value };
+        p.color = { rgb: hexToRgb(particles.color.value) };
+        p.shape = undefined;       // falls back to particles.shape.type
+        p.character = undefined;   // falls back to particles.shape.character
+        p.charIndex = (Math.random() * 1024) | 0;
+        p.startX = p.x;
+        p.startY = p.y;
+        p.seed = Math.random() * 1000;
+        // Benign defaults for the app's custom tags so hot paths never see undefined
+        p.isCrystalized = false;
+        p.isInfected = false;
+        p.isEntangled = false;
+        p.isConsumed = 0;
+        p.unravelling = 0;
+        p.fading = 0;
+        p.colorLocked = false;
+        p.isHeavy = false;
+        p.isCoral = false;
+        p.isStatic = false;
+        p.bondPartner = null;
+        p.chainParent = null;
+        p.chainChild = null;
+        return p;
+    }
+
+    /** Particle count honoring the density model (config value per value_area px²). */
+    function densityCount() {
+        const num = particles.number;
+        if (!num.density || !num.density.enable) return num.value;
+        const area = (pJS.canvas.w * pJS.canvas.h) / 1000;
+        const n = Math.round((area * num.value) / num.density.value_area);
+        return Math.min(Math.max(n, 30), num.value_max || n);
+    }
+
+    pJS.fn.particlesRefresh = function () {
+        for (const p of particles.array) {
+            if (pool.length < 600) pool.push(p);
+        }
+        particles.array.length = 0;
+        const n = densityCount();
+        for (let i = 0; i < n; i++) particles.array.push(createParticle());
+    };
+
+    pJS.fn.modes = {
+        /** Create `n` particles (at pos if given). Returns the new particles. */
+        pushParticles(n, pos) {
+            const created = [];
+            for (let i = 0; i < n; i++) {
+                const p = createParticle(pos ? pos.x : undefined, pos ? pos.y : undefined);
+                particles.array.push(p);
+                created.push(p);
+            }
+            return created;
+        },
+    };
+
+    pJS.fn.particlesUpdate = function () {
+        const arr = particles.array;
+        const w = pJS.canvas.w;
+        const h = pJS.canvas.h;
+        // Old library moved at speed/2 per update but updated twice per frame;
+        // a single honest update at full speed preserves the tuned feel.
+        const ms = particles.move.speed;
+        const bounce = particles.move.out_mode === 'bounce';
+
+        for (let i = 0; i < arr.length; i++) {
+            const p = arr[i];
+            if (particles.move.enable !== false && !p.isStatic) {
+                p.x += p.vx * ms * 0.5;
+                p.y += p.vy * ms * 0.5;
+                p.x += p.vx * ms * 0.5;
+                p.y += p.vy * ms * 0.5;
+            }
+
+            if (bounce) {
+                if (p.x - p.radius < 0) { p.x = p.radius; p.vx = Math.abs(p.vx); }
+                else if (p.x + p.radius > w) { p.x = w - p.radius; p.vx = -Math.abs(p.vx); }
+                if (p.y - p.radius < 0) { p.y = p.radius; p.vy = Math.abs(p.vy); }
+                else if (p.y + p.radius > h) { p.y = h - p.radius; p.vy = -Math.abs(p.vy); }
+            } else {
+                // 'out': wrap to the opposite edge
+                if (p.x - p.radius > w) p.x = -p.radius;
+                else if (p.x + p.radius < 0) p.x = w + p.radius;
+                if (p.y - p.radius > h) p.y = -p.radius;
+                else if (p.y + p.radius < 0) p.y = h + p.radius;
+            }
+
+            // Bubble hover: particles swell near the cursor and relax via the
+            // simulation's existing radius decay
+            if (bubbleOn && bubble) {
+                const dx = p.x - mouse.x;
+                const dy = p.y - mouse.y;
+                const distSq = dx * dx + dy * dy;
+                const bd = bubble.distance;
+                if (distSq < bd * bd) {
+                    const target = p.radius_initial + (bubble.size || 8) * (1 - Math.sqrt(distSq) / bd);
+                    if (p.radius < target) p.radius += (target - p.radius) * 0.08;
+                }
+            }
+        }
+
+        // Mutual attraction (rarely enabled; matches the old library's scale)
+        if (particles.move.attract.enable) {
+            const ax = 1 / (particles.move.attract.rotateX * 1000);
+            const ay = 1 / (particles.move.attract.rotateY * 1000);
+            for (let i = 0; i < arr.length; i++) {
+                for (let j = i + 1; j < arr.length; j++) {
+                    const dx = arr[i].x - arr[j].x;
+                    const dy = arr[i].y - arr[j].y;
+                    arr[i].vx -= dx * ax; arr[i].vy -= dy * ay;
+                    arr[j].vx += dx * ax; arr[j].vy += dy * ay;
+                }
+            }
+        }
+    };
+
+    function tracePolygon(x, y, r, sides, rot) {
+        ctx.moveTo(x + r * Math.cos(rot), y + r * Math.sin(rot));
+        for (let i = 1; i <= sides; i++) {
+            const a = rot + (i / sides) * TAU;
+            ctx.lineTo(x + r * Math.cos(a), y + r * Math.sin(a));
+        }
+    }
+
+    function traceStar(x, y, r) {
+        const rot = -Math.PI / 2;
+        ctx.moveTo(x + r * Math.cos(rot), y + r * Math.sin(rot));
+        for (let i = 1; i <= 10; i++) {
+            const a = rot + (i / 10) * TAU;
+            const rr = i % 2 === 0 ? r : r * 0.45;
+            ctx.lineTo(x + rr * Math.cos(a), y + rr * Math.sin(a));
+        }
+    }
+
+    function drawLinks(arr) {
+        const dist = particles.line_linked.distance;
+        const distSqMax = dist * dist;
+        const baseAlpha = particles.line_linked.opacity;
+        // Batch segments into 3 alpha bands to avoid a stroke() per pair
+        const bands = [[], [], []];
+        for (let i = 0; i < arr.length; i++) {
+            const a = arr[i];
+            for (let j = i + 1; j < arr.length; j++) {
+                const b = arr[j];
+                const dx = a.x - b.x;
+                const dy = a.y - b.y;
+                const d2 = dx * dx + dy * dy;
+                if (d2 < distSqMax) {
+                    const band = d2 < distSqMax * 0.25 ? 0 : d2 < distSqMax * 0.6 ? 1 : 2;
+                    bands[band].push(a.x, a.y, b.x, b.y);
+                }
+            }
+        }
+        ctx.lineWidth = 1;
+        const alphas = [baseAlpha, baseAlpha * 0.55, baseAlpha * 0.25];
+        for (let b = 0; b < 3; b++) {
+            const seg = bands[b];
+            if (seg.length === 0) continue;
+            ctx.strokeStyle = `rgba(255, 255, 255, ${alphas[b]})`;
+            ctx.beginPath();
+            for (let k = 0; k < seg.length; k += 4) {
+                ctx.moveTo(seg[k], seg[k + 1]);
+                ctx.lineTo(seg[k + 2], seg[k + 3]);
+            }
+            ctx.stroke();
+        }
+    }
+
+    pJS.fn.particlesDraw = function () {
+        const arr = particles.array;
+        const w = pJS.canvas.w;
+        const h = pJS.canvas.h;
+
+        // Trails: erase a fraction of the previous frame (keeps the canvas
+        // transparent over the background); otherwise clear fully.
+        if (particles.move.trail.enable) {
+            ctx.save();
+            ctx.globalCompositeOperation = 'destination-out';
+            ctx.fillStyle = `rgba(0, 0, 0, ${Math.min(1, 1 / particles.move.trail.length)})`;
+            ctx.fillRect(0, 0, w, h);
+            ctx.restore();
+        } else {
+            ctx.clearRect(0, 0, w, h);
+        }
+
+        if (particles.line_linked.enable && arr.length > 1) drawLinks(arr);
+
+        const globalShape = particles.shape.type;
+        const nbSides = particles.shape.polygon.nb_sides || 5;
+        const globalChars = particles.shape.character.value;
+
+        for (let i = 0; i < arr.length; i++) {
+            const p = arr[i];
+            const op = p.opacity.value;
+            if (op <= 0) continue;
+            const rgb = p.color.rgb;
+            const r = Math.max(0.4, p.radius);
+            const shape = p.shape || globalShape;
+            ctx.fillStyle = `rgba(${rgb.r | 0}, ${rgb.g | 0}, ${rgb.b | 0}, ${op})`;
+
+            if (shape === 'character' || shape === 'char') {
+                const chars = (p.character && p.character.value) || globalChars || ['*'];
+                const c = chars[p.charIndex % chars.length];
+                ctx.font = `${Math.max(8, r * 4)}px monospace`;
+                ctx.fillText(c, p.x - r, p.y + r);
+                continue;
+            }
+            ctx.beginPath();
+            if (shape === 'edge' || shape === 'square') {
+                ctx.rect(p.x - r, p.y - r, r * 2, r * 2);
+            } else if (shape === 'triangle') {
+                tracePolygon(p.x, p.y, r * 1.3, 3, -Math.PI / 2);
+            } else if (shape === 'polygon') {
+                tracePolygon(p.x, p.y, r * 1.2, nbSides, -Math.PI / 2);
+            } else if (shape === 'star') {
+                traceStar(p.x, p.y, r * 1.4);
+            } else {
+                ctx.arc(p.x, p.y, r, 0, TAU);
+            }
+            ctx.fill();
+        }
+    };
+
+    // Throttled resize, matching the app's other canvases
+    let resizeTimer = 0;
+    window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(resize, 100);
+    });
+
+    resize();
+    pJS.fn.particlesRefresh();
+    return pJS;
+}

--- a/js/post_processing.js
+++ b/js/post_processing.js
@@ -267,9 +267,11 @@ class PostProcessingSystem {
             const angle = this.lightLeakAngle;
             const cx = w * (0.3 + 0.4 * Math.cos(angle));
             const cy = h * (0.3 + 0.4 * Math.sin(angle));
-            // Cache light leak gradient (perf: avoid recreating radial gradient every frame)
+            // Cache light leak gradient (perf: avoid recreating radial gradient every frame).
+            // Note: comparisons must parenthesize the |0 truncation — `a !== b | 0`
+            // parses as `(a !== b) | 0`, which made this cache miss on every frame.
             if (!this._leakGrad || this._leakW !== w || this._leakH !== h ||
-                this._leakCx !== cx | 0 || this._leakCy !== cy | 0) {
+                this._leakCx !== (cx | 0) || this._leakCy !== (cy | 0)) {
                 this._leakGrad = ctx.createRadialGradient(
                     cx, cy, 0,
                     cx, cy, Math.max(w, h) * 0.5

--- a/js/postcard.js
+++ b/js/postcard.js
@@ -1,0 +1,153 @@
+/**
+ * @file postcard.js
+ * @description Press O to keep a souvenir: composes the live render layers
+ * into a framed postcard PNG, captioned with the universe's field-guide
+ * epithet and surveyor's note (lore_codex.js), the seed, and its epoch and
+ * generation (epoch_system.js). A screenshot is data; a postcard is a story.
+ */
+
+import { currentSeed } from './state.js';
+import { screenshot } from './screenshot.js';
+import { loreCodex } from './lore_codex.js';
+import { epochSystem, toRoman } from './epoch_system.js';
+
+const CARD_W = 1400;
+const CARD_H = 1050;
+const MARGIN = 64;
+const CAPTION_H = 190;
+
+function wrapText(ctx, text, maxWidth, maxLines) {
+    const words = text.split(' ');
+    const lines = [];
+    let line = '';
+    for (const word of words) {
+        const probe = line ? line + ' ' + word : word;
+        if (ctx.measureText(probe).width > maxWidth && line) {
+            lines.push(line);
+            line = word;
+            if (lines.length === maxLines - 1) break;
+        } else {
+            line = probe;
+        }
+    }
+    if (line && lines.length < maxLines) lines.push(line);
+    return lines;
+}
+
+export const postcard = {
+    _link: null,
+
+    init() {
+        this._link = document.createElement('a');
+        this._link.style.display = 'none';
+        document.body.appendChild(this._link);
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key !== 'o' && e.key !== 'O') return;
+            if (e.ctrlKey || e.metaKey || e.altKey) return;
+            const el = document.activeElement;
+            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+            this.download();
+            screenshot.showFlash();
+        });
+    },
+
+    compose() {
+        const card = document.createElement('canvas');
+        card.width = CARD_W;
+        card.height = CARD_H;
+        const ctx = card.getContext('2d');
+
+        // Card stock
+        ctx.fillStyle = '#0b0b12';
+        ctx.fillRect(0, 0, CARD_W, CARD_H);
+
+        // Art window: cover-fit the live composite
+        const artX = MARGIN;
+        const artY = MARGIN;
+        const artW = CARD_W - MARGIN * 2;
+        const artH = CARD_H - MARGIN * 2 - CAPTION_H;
+        ctx.fillStyle = '#000';
+        ctx.fillRect(artX, artY, artW, artH);
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(artX, artY, artW, artH);
+        ctx.clip();
+        const srcW = window.innerWidth;
+        const srcH = window.innerHeight;
+        const scale = Math.max(artW / srcW, artH / srcH);
+        const dw = srcW * scale;
+        const dh = srcH * scale;
+        const dx = artX + (artW - dw) / 2;
+        const dy = artY + (artH - dh) / 2;
+        for (const layer of screenshot.collectLayers()) {
+            try {
+                ctx.drawImage(layer, dx, dy, dw, dh);
+            } catch (err) {
+                console.warn('[postcard] Could not draw layer:', err.message ?? err);
+            }
+        }
+        ctx.restore();
+
+        // Frame: outer hairline + corner ticks
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.35)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(artX - 8.5, artY - 8.5, artW + 17, artH + CAPTION_H - 20 + 17);
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.7)';
+        ctx.lineWidth = 2;
+        const tick = 22;
+        for (const [cx, cy, sx, sy] of [
+            [artX - 8, artY - 8, 1, 1],
+            [artX + artW + 8, artY - 8, -1, 1],
+            [artX - 8, artY + artH + CAPTION_H - 20 + 8, 1, -1],
+            [artX + artW + 8, artY + artH + CAPTION_H - 20 + 8, -1, -1],
+        ]) {
+            ctx.beginPath();
+            ctx.moveTo(cx + sx * tick, cy);
+            ctx.lineTo(cx, cy);
+            ctx.lineTo(cx, cy + sy * tick);
+            ctx.stroke();
+        }
+
+        // Caption block
+        const lore = loreCodex.current;
+        const capY = artY + artH + 44;
+        ctx.textBaseline = 'alphabetic';
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.92)';
+        ctx.font = 'italic 30px "Exo 2", Georgia, serif';
+        ctx.fillText(lore ? lore.epithet : '“An Uncharted Reach”', artX + 4, capY);
+
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
+        ctx.font = '17px "Exo 2", Georgia, serif';
+        const noteLines = wrapText(ctx, lore ? lore.note : '', artW - 360, 2);
+        noteLines.forEach((line, i) => ctx.fillText(line, artX + 4, capY + 32 + i * 24));
+
+        // Provenance, bottom-right: seed · generation · epoch
+        const gen = epochSystem.current.generation;
+        const provenance = [
+            currentSeed || 'UNKNOWN',
+            gen > 1 ? `Gen ${toRoman(gen)}` : '',
+            epochSystem.current.name,
+        ].filter(Boolean).join('  ·  ');
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.45)';
+        ctx.font = '14px monospace';
+        ctx.textAlign = 'right';
+        ctx.fillText(provenance, artX + artW - 4, capY + 32 + 24);
+        ctx.textAlign = 'left';
+
+        return card;
+    },
+
+    download() {
+        const card = this.compose();
+        card.toBlob((blob) => {
+            if (!blob) return;
+            const url = URL.createObjectURL(blob);
+            this._link.href = url;
+            const seed = (currentSeed || 'universe').replace(/[^\w-]/g, '');
+            this._link.download = `celestial-postcard-${seed}.png`;
+            this._link.click();
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+        }, 'image/png');
+    },
+};

--- a/js/powers.js
+++ b/js/powers.js
@@ -46,7 +46,9 @@ export function handleActivePower(p, i, pJS, powerName, worldMouse) {
         case 'resonate': if(distSq < 22500){ p.vx += Math.sin(tick*0.8+p.seed)*0.1; p.vy += Math.cos(tick*0.8+p.seed)*0.1; } break;
         case 'dampen': if(distSq < 22500){ p.vx *= 0.95; p.vy *= 0.95; } break;
         case 'smudge': if(distSq < 22500){ if(p.radius < 15) p.radius += 0.05; p.opacity.value = Math.max(0.1, p.opacity.value*0.99); } break;
-        case 'draw': if(distSq < 400 && pJS.particles.array.length < pJS.particles.number.value_max) { const newP = {...p, x: worldMouse.x+(seededRandom()-0.5)*5, y: worldMouse.y+(seededRandom()-0.5)*5}; pJS.particles.array.push(newP); tagParticles([newP], universeProfile, isInitialLoad, seededRandom); } break;
+        // Note: this used to spread-clone the source particle, which shared the
+        // opacity/color OBJECTS between clone and original — fading one faded both.
+        case 'draw': if(distSq < 400 && pJS.particles.array.length < pJS.particles.number.value_max) { const newP = pJS.fn.modes.pushParticles(1, {x: worldMouse.x+(seededRandom()-0.5)*5, y: worldMouse.y+(seededRandom()-0.5)*5})[0]; if(newP) { newP.color = {rgb: {...p.color.rgb}}; newP.radius = p.radius; newP.vx = p.vx * 0.5; newP.vy = p.vy * 0.5; tagParticles([newP], universeProfile, isInitialLoad, seededRandom); } } break;
         case 'consume': if (distSq < 22500) { p.isConsumed = 100; } break;
         case 'maddeningWhisper': if (distSq < 40000) { p.vx += (seededRandom() - 0.5) * 0.4; p.vy += (seededRandom() - 0.5) * 0.4; } break;
         case 'smear': if (distSq < 22500) { p.vx += (worldMouse.x - p.x) * 0.02; p.vy += (worldMouse.y - p.y) * 0.02; p.color = { rgb: { r:255, g:255, b:255 } }; } break;

--- a/js/screenshot.js
+++ b/js/screenshot.js
@@ -17,6 +17,32 @@ export const screenshot = {
     });
   },
 
+  /** All visible render layers, back to front (shared with postcard.js). */
+  collectLayers() {
+    const layers = [];
+
+    const bg = document.querySelector('#background-canvas');
+    if (bg) layers.push(bg);
+
+    const particlesContainer = document.querySelector('#particles-js');
+    if (particlesContainer) {
+      const pc = particlesContainer.querySelector('canvas');
+      if (pc) layers.push(pc);
+    }
+
+    const overlayIds = [
+      '#cursor-effects-canvas',
+      '#cursor-trail-canvas',
+      '#ambient-fx-canvas',
+      '#warp-field-canvas',
+    ];
+    for (const id of overlayIds) {
+      const el = document.querySelector(id);
+      if (el) layers.push(el);
+    }
+    return layers;
+  },
+
   capture() {
     return new Promise((resolve) => {
       const composite = document.createElement('canvas');
@@ -24,29 +50,7 @@ export const screenshot = {
       composite.height = window.innerHeight;
       const ctx = composite.getContext('2d');
 
-      const layers = [];
-
-      const bg = document.querySelector('#background-canvas');
-      if (bg) layers.push(bg);
-
-      const particlesContainer = document.querySelector('#particles-js');
-      if (particlesContainer) {
-        const pc = particlesContainer.querySelector('canvas');
-        if (pc) layers.push(pc);
-      }
-
-      const overlayIds = [
-        '#cursor-effects-canvas',
-        '#cursor-trail-canvas',
-        '#ambient-fx-canvas',
-        '#warp-field-canvas',
-      ];
-      for (const id of overlayIds) {
-        const el = document.querySelector(id);
-        if (el) layers.push(el);
-      }
-
-      for (const canvas of layers) {
+      for (const canvas of this.collectLayers()) {
         try {
           ctx.drawImage(canvas, 0, 0, composite.width, composite.height);
         } catch (err) {

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -19,6 +19,7 @@ import { hud } from './hud.js';
 import { inputToolbar } from './input_toolbar.js';
 import { perfMonitor } from './perf_monitor.js';
 import { touchGestures } from './touch_gestures.js';
+import { epochSystem } from './epoch_system.js';
 
 // --- Simulation Sub-modules ---
 
@@ -919,6 +920,7 @@ export function update(pJS) {
     hud.update(performance.now());
     inputToolbar.update();
 
+    epochSystem.update(pJS);
     handleEnergyAndCataclysm(pJS);
     prepareCanvas(pJS);
     rebuildMutatorCache();

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -42,12 +42,6 @@ function handleEnergyAndCataclysm(pJS) {
     }
 }
 
-function prepareCanvas(pJS) {
-    const trailAlpha = pJS.particles.move.trail.enable ? (universeProfile.blueprintName === 'LivingInk' || universeProfile.blueprintName === 'Painterly' ? 0.2 : 0.1) : 1;
-    pJS.canvas.ctx.fillStyle = `rgba(0, 0, 0, ${trailAlpha})`;
-    pJS.canvas.ctx.fillRect(0, 0, pJS.canvas.w, pJS.canvas.h);
-}
-
 function applyOngoingEffects(p, i, pJS) {
     const arr = pJS.particles.array;
     if (p.unravelling > 0) { p.unravelling--; p.radius *= 0.98; if (p.unravelling <= 0) { arr[i] = arr[arr.length - 1]; arr.pop(); return true; } }
@@ -922,7 +916,7 @@ export function update(pJS) {
 
     epochSystem.update(pJS);
     handleEnergyAndCataclysm(pJS);
-    prepareCanvas(pJS);
+    // Canvas clearing / trail fading is owned by the engine's particlesDraw()
     rebuildMutatorCache();
     precomputeChoralAverage(pJS);
     precomputeRiverSamples();

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -882,14 +882,18 @@ function enforceParticleLimit(pJS) {
 // Reusable mouse object to avoid per-frame allocation from { ...mouse }
 const _worldMouse = { x: 0, y: 0 };
 
+// Cached RAF callback (avoids allocating a fresh closure every frame)
+let _rafLoop = null;
+
 /**
  * The main update loop, called on every frame.
  * This function handles particle physics, user interaction, anomalies, and cataclysms.
  */
 export function update(pJS) {
+    if (_rafLoop === null) _rafLoop = () => update(pJS);
     incrementTick();
     if (cataclysmInProgress) {
-        requestAnimationFrame(() => update(pJS));
+        requestAnimationFrame(_rafLoop);
         return;
     }
 
@@ -935,5 +939,5 @@ export function update(pJS) {
     pJS.fn.particlesUpdate();
     pJS.fn.particlesDraw();
 
-    requestAnimationFrame(() => update(pJS));
+    requestAnimationFrame(_rafLoop);
 }

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -5,6 +5,7 @@
 
 import { cataclysmInProgress, universeState, setUniverseState, isLeftMouseDown, isRightMouseDown, activeEffects, universeProfile, physics, mouse, seededRandom } from './state.js';
 import { triggerCataclysm } from './cataclysms.js';
+import { ambientEvents } from './effects.js';
 import { handleActivePower } from './powers.js';
 import { getBezierXY, tagParticles } from './utils.js';
 import { drawEffects } from './drawing.js';
@@ -97,6 +98,30 @@ function applyWhiteHoleForce(p) {
             const force = hole.strength / (Math.sqrt(distSq) + 0.1);
             p.vx -= dx * force * 0.1;
             p.vy -= dy * force * 0.1;
+        }
+    }
+}
+
+function applyCosmicStringForce(p) {
+    for (const s of activeEffects.cosmicStrings) {
+        const dx = s.x2 - s.x1;
+        const dy = s.y2 - s.y1;
+        const len2 = dx * dx + dy * dy;
+        if (len2 < 1) continue;
+        let t = ((p.x - s.x1) * dx + (p.y - s.y1) * dy) / len2;
+        t = t < 0 ? 0 : t > 1 ? 1 : t;
+        const ox = s.x1 + dx * t - p.x;
+        const oy = s.y1 + dy * t - p.y;
+        const dSq = ox * ox + oy * oy;
+        if (dSq < 14400 && dSq > 4) { // within 120px of the string
+            const d = Math.sqrt(dSq);
+            const pull = s.strength * 0.002 * (1 - d / 120);
+            // Drawn toward the string, then carried along it
+            p.vx += (ox / d) * pull * 10;
+            p.vy += (oy / d) * pull * 10;
+            const len = Math.sqrt(len2);
+            p.vx += (dx / len) * pull * 4;
+            p.vy += (dy / len) * pull * 4;
         }
     }
 }
@@ -273,6 +298,7 @@ function applyAnomalyForces(p, i, pJS) {
     if (activeEffects.pulsars.length > 0) applyPulsarForce(p);
     if (activeEffects.blackHoles.length > 0 && applyBlackHoleForce(p, i, pJS)) return true;
     if (activeEffects.whiteHoles.length > 0) applyWhiteHoleForce(p);
+    if (activeEffects.cosmicStrings.length > 0) applyCosmicStringForce(p);
     if (activeEffects.cosmicWebs.length > 0) applyCosmicWebForce(p);
     if (activeEffects.quasars.length > 0) applyQuasarForce(p);
     if (activeEffects.cosmicRifts.length > 0) applyCosmicRiftForce(p);
@@ -929,6 +955,16 @@ export function update(pJS) {
 
     updateEntangledGroups(pJS);
     updateAnomalies(pJS);
+
+    // Ambient events: each universe's blueprint event fires on a seeded cadence
+    // (previously profile.ambientEvent was selected but never consumed)
+    const tick = getTick();
+    if (universeProfile.ambientEvent && universeProfile.eventInterval
+        && tick > 0 && tick % universeProfile.eventInterval === 0) {
+        const fireEvent = ambientEvents[universeProfile.ambientEvent];
+        if (fireEvent) fireEvent(pJS, seededRandom, activeEffects);
+    }
+
     enforceParticleLimit(pJS);
 
     drawEffects(pJS.canvas.ctx);

--- a/js/ui.js
+++ b/js/ui.js
@@ -71,7 +71,10 @@ export function initializeEventListeners(pJS) {
         clearTimeout(resizeTimeout);
         resizeTimeout = setTimeout(() => {
             if (pJS && currentSeed && !cataclysmInProgress) {
-                generateUniverse(pJS, currentSeed, true);
+                // Re-lay out the SAME universe at the new size. (isNewSeed=true
+                // here used to discard currentSeed and roll a random universe
+                // on every window resize.)
+                generateUniverse(pJS, currentSeed, false);
             }
         }, 250);
     });

--- a/js/universe.js
+++ b/js/universe.js
@@ -16,6 +16,7 @@ import { ambientFX } from './ambient_fx.js';
 import { warpField } from './warp_field.js';
 import { ambientSound } from './ambient_sound.js';
 import { interactiveEffects } from './interactive_background_effects.js';
+import { loreCodex } from './lore_codex.js';
 
 /**
  * Generates a new universe based on a seed.
@@ -104,6 +105,9 @@ export const generateUniverse = (pJS, seed, isNewSeed = false) => {
         profile.anomaly = anomalyName;
         anomalies[anomalyName](pJS, seededRandom, activeEffects);
     }
+
+    // Write this universe's field-guide entry
+    loreCodex.generate(seededRandom, blueprintName);
 
     updateUI();
 

--- a/js/universe.js
+++ b/js/universe.js
@@ -17,6 +17,7 @@ import { warpField } from './warp_field.js';
 import { ambientSound } from './ambient_sound.js';
 import { interactiveEffects } from './interactive_background_effects.js';
 import { loreCodex } from './lore_codex.js';
+import { journal } from './journal.js';
 
 /**
  * Generates a new universe based on a seed.
@@ -56,6 +57,8 @@ export const generateUniverse = (pJS, seed, isNewSeed = false) => {
     pJS.particles.number.value = 150; pJS.particles.number.value_max = 400;
     pJS.particles.move.speed = 1 + seededRandom() * 3;
     pJS.particles.move.trail.enable = !!blueprint.aesthetic.trails;
+    // Engine fades 1/length per frame; painterly universes repaint faster
+    pJS.particles.move.trail.length = (blueprintName === 'LivingInk' || blueprintName === 'Painterly') ? 5 : 10;
     pJS.particles.shape.type = blueprint.aesthetic.shape;
     if (blueprintName === 'Digital') pJS.particles.shape.character.value = blueprint.aesthetic.chars;
     if (blueprintName === 'Eldritch' || blueprintName === 'ArcaneCodex') pJS.particles.shape.polygon.nb_sides = blueprint.aesthetic.sides;
@@ -106,8 +109,9 @@ export const generateUniverse = (pJS, seed, isNewSeed = false) => {
         anomalies[anomalyName](pJS, seededRandom, activeEffects);
     }
 
-    // Write this universe's field-guide entry
+    // Write this universe's field-guide entry and chart it in the journal
     loreCodex.generate(seededRandom, blueprintName);
+    journal.record(newSeed, blueprintName);
 
     updateUI();
 

--- a/js/universe.js
+++ b/js/universe.js
@@ -44,6 +44,8 @@ export const generateUniverse = (pJS, seed, isNewSeed = false) => {
         rightClickPower: blueprint.right[Math.floor(seededRandom() * blueprint.right.length)],
         ambientEvent: blueprint.events[Math.floor(seededRandom() * blueprint.events.length)],
         cataclysm: blueprint.cataclysms[Math.floor(seededRandom() * blueprint.cataclysms.length)],
+        // Ambient event cadence: roughly every 12-27 seconds at 60fps
+        eventInterval: 700 + Math.floor(seededRandom() * 900),
         mutators: [],
         anomaly: null
     };

--- a/js/video_export.js
+++ b/js/video_export.js
@@ -1,0 +1,150 @@
+/**
+ * @file video_export.js
+ * @description Record the living canvas to a downloadable WebM clip using
+ * canvas.captureStream + MediaRecorder. Both render layers (the background
+ * system canvas and the particles.js canvas) are composited into one export
+ * canvas per frame while recording. Press R or use the ⏺ toolbar button;
+ * recording stops on a second press or automatically at 30 seconds.
+ */
+
+import { background } from './background.js';
+import { currentSeed } from './state.js';
+
+const MAX_SECONDS = 30;
+
+export const videoExport = {
+    supported: typeof window !== 'undefined'
+        && !!window.MediaRecorder
+        && !!HTMLCanvasElement.prototype.captureStream,
+    recording: false,
+
+    _canvas: null,
+    _ctx: null,
+    _recorder: null,
+    _chunks: [],
+    _badge: null,
+    _badgeText: null,
+    _startedAt: 0,
+    _rafId: 0,
+
+    init() {
+        if (!this.supported) return;
+        document.addEventListener('keydown', (e) => {
+            const el = document.activeElement;
+            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+            if (e.key === 'r' || e.key === 'R') this.toggle();
+        });
+    },
+
+    toggle() {
+        if (this.recording) this.stop();
+        else this.start();
+    },
+
+    start() {
+        if (this.recording || !this.supported) return;
+
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        if (!this._canvas) {
+            this._canvas = document.createElement('canvas');
+            this._ctx = this._canvas.getContext('2d');
+        }
+        this._canvas.width = w;
+        this._canvas.height = h;
+
+        const mime = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm']
+            .find(m => MediaRecorder.isTypeSupported(m));
+        if (!mime) return;
+
+        const stream = this._canvas.captureStream(60);
+        this._chunks = [];
+        this._recorder = new MediaRecorder(stream, { mimeType: mime, videoBitsPerSecond: 8_000_000 });
+        this._recorder.ondataavailable = (e) => {
+            if (e.data && e.data.size > 0) this._chunks.push(e.data);
+        };
+        this._recorder.onstop = () => this._download(mime);
+        this._recorder.start(1000);
+
+        this.recording = true;
+        this._startedAt = performance.now();
+        this._showBadge();
+        this._composite();
+    },
+
+    stop() {
+        if (!this.recording) return;
+        this.recording = false;
+        cancelAnimationFrame(this._rafId);
+        this._hideBadge();
+        if (this._recorder && this._recorder.state !== 'inactive') this._recorder.stop();
+    },
+
+    /** Per-frame: stack the render layers into the export canvas. */
+    _composite() {
+        if (!this.recording) return;
+        const ctx = this._ctx;
+        const w = this._canvas.width;
+        const h = this._canvas.height;
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, w, h);
+        if (background.canvas && background.canvas.width > 0) {
+            ctx.drawImage(background.canvas, 0, 0, w, h);
+        }
+        const pCanvas = document.querySelector('#particles-js canvas');
+        if (pCanvas && pCanvas.width > 0) {
+            ctx.drawImage(pCanvas, 0, 0, w, h);
+        }
+
+        const elapsed = (performance.now() - this._startedAt) / 1000;
+        if (this._badgeText) {
+            this._badgeText.textContent = `REC ${elapsed.toFixed(0)}s · R to stop`;
+        }
+        if (elapsed >= MAX_SECONDS) {
+            this.stop();
+            return;
+        }
+        this._rafId = requestAnimationFrame(() => this._composite());
+    },
+
+    _download(mime) {
+        if (this._chunks.length === 0) return;
+        const blob = new Blob(this._chunks, { type: mime });
+        this._chunks = [];
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        const seed = (currentSeed || 'universe').replace(/[^\w-]/g, '');
+        a.download = `celestial-${seed}.webm`;
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 5000);
+    },
+
+    _showBadge() {
+        if (!this._badge) {
+            const badge = document.createElement('div');
+            badge.style.cssText =
+                'position:fixed;top:12px;left:12px;z-index:102;display:flex;align-items:center;gap:7px;' +
+                'padding:5px 12px;border-radius:14px;background:rgba(10,10,14,0.7);' +
+                'border:1px solid rgba(255,80,80,0.5);font-family:"Exo 2",sans-serif;' +
+                'font-size:11px;color:rgba(255,200,200,0.95);pointer-events:none;';
+            const dot = document.createElement('span');
+            dot.style.cssText =
+                'width:8px;height:8px;border-radius:50%;background:#ff4d4d;' +
+                'animation:recBlink 1.2s ease-in-out infinite;';
+            const style = document.createElement('style');
+            style.textContent = '@keyframes recBlink{0%,100%{opacity:1}50%{opacity:0.25}}';
+            document.head.appendChild(style);
+            this._badgeText = document.createElement('span');
+            badge.appendChild(dot);
+            badge.appendChild(this._badgeText);
+            this._badge = badge;
+        }
+        this._badgeText.textContent = 'REC 0s · R to stop';
+        document.body.appendChild(this._badge);
+    },
+
+    _hideBadge() {
+        if (this._badge && this._badge.parentNode) this._badge.remove();
+    },
+};

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Celestial Canvas",
+  "short_name": "Celestial",
+  "description": "A seeded multiverse of generative universes. Every seed is a different world; every world ages, remembers you, and can be kept as a postcard.",
+  "start_url": ".",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#000000",
+  "theme_color": "#0b0b12",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,68 @@
+/**
+ * @file sw.js
+ * @description Service worker: makes Celestial Canvas installable and fully
+ * offline-capable. Strategy is network-first with runtime caching — every
+ * successfully fetched same-origin asset (the app shell plus all ES modules
+ * as they load) lands in the cache, so after one visit the multiverse runs
+ * with no connection at all, while online visits always get fresh code.
+ * Google Fonts responses are cached opaquely as a best effort.
+ */
+
+const CACHE = 'celestial-canvas-v1';
+
+const PRECACHE = [
+    './',
+    'index.html',
+    'css/style.css',
+    'manifest.webmanifest',
+    'icons/icon.svg',
+    'icons/icon-maskable.svg',
+    'js/main.js',
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE)
+            .then((cache) => cache.addAll(PRECACHE))
+            .then(() => self.skipWaiting())
+    );
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys()
+            .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+            .then(() => self.clients.claim())
+    );
+});
+
+self.addEventListener('fetch', (event) => {
+    const req = event.request;
+    if (req.method !== 'GET') return;
+
+    const url = new URL(req.url);
+    const sameOrigin = url.origin === self.location.origin;
+    const isFont = url.hostname.endsWith('gstatic.com') || url.hostname.endsWith('googleapis.com');
+    if (!sameOrigin && !isFont) return;
+
+    event.respondWith(
+        fetch(req)
+            .then((res) => {
+                // Runtime-cache anything that arrived intact (opaque allowed for fonts)
+                if (res && (res.ok || res.type === 'opaque')) {
+                    const copy = res.clone();
+                    caches.open(CACHE).then((cache) => cache.put(req, copy)).catch(() => {});
+                }
+                return res;
+            })
+            .catch(() =>
+                caches.match(req, { ignoreSearch: sameOrigin && req.mode === 'navigate' })
+                    .then((hit) => {
+                        if (hit) return hit;
+                        // Offline navigation to any ?seed=... falls back to the shell
+                        if (req.mode === 'navigate') return caches.match('index.html');
+                        return Response.error();
+                    })
+            )
+    );
+});


### PR DESCRIPTION
This PR introduces three major new systems to Celestial Canvas:

## Summary
Adds interactive metro transit maps, cursor familiar creatures, offline PWA support, and supporting infrastructure (particle engine replacement, lore generation, epoch system, journal, postcard export, video recording, MIDI input).

## Key Changes

**Metro Transit System** (`metro_transit_effects.js`, `metro_map_generator.js`)
- Seeded procedural generator for octilinear transit networks with 4 topologies (weave, spokes, orbital, riverside)
- 2-7 distinct colored lines with stations, interchanges, and optional river bands
- Real-time train simulation with arc-length lookup, passenger collection, and interactive express dispatch
- Static map pre-rendered to offscreen canvas for performance; only trains and passengers update per frame

**Cursor Familiar** (`cursor_familiar.js`, `familiar_species.js`, `familiar_memory.js`)
- Seeded companion creature that spring-follows the cursor with species-specific locomotion
- 6 species (wisp, moth flock, serpent, shard, ink sprite, constellation) with distinct animations
- Behavior modes: follow (excited by movement), doze (idle), startle (on click)
- Persistent memory: localStorage tracks playtime, names the creature, unlocks growth stages (hatchling → mythic)
- Replaces old generic inline effects (ripples, mouse trail, gravity field, heat map, echo ghosts, constellation links)

**Offline & PWA Support** (`sw.js`, `manifest.webmanifest`)
- Service worker with network-first caching strategy for full offline capability
- Web app manifest for installability
- App icons (SVG, maskable variant)

**Supporting Systems**
- **Particle Engine** (`particle_engine.js`): In-house replacement for particles.js v2 CDN dependency
  - Fixes double-update bug (v2 called update inside draw)
  - Proper trail fading via destination-out compositing
  - DPR-aware rendering (CSS pixels for logic, device pixels for backing store)
  - Returns created particles for proper tagging
- **Lore Generation** (`lore_codex.js`): Procedural field guide epithets and surveyor notes themed to blueprints
- **Epoch System** (`epoch_system.js`): Universes age through 4 epochs (~5 min each) with modulated speed/brightness; rebirth increments generation numeral
- **Journal** (`journal.js`): localStorage-backed constellation notebook; press J to browse visited universes
- **Postcard Export** (`postcard.js`): Press O to save framed PNG with epithet, seed, epoch, generation
- **Video Export** (`video_export.js`): Press R to record WebM clip via MediaRecorder
- **MIDI Input** (`midi_input.js`): Hardware controller support; knobs auto-learn, notes trigger shockwaves
- **Environment Sense** (`environment_sense.js`): Adapts to prefers-reduced-motion, battery status, screen wake lock

**Integration Changes**
- `interactive_background_effects.js`: Removed inline effect toggles/pools; now delegates to registry and cursor familiar
- `background.js`: Added MIDI and environment sense initialization
- `simulation.js`: Integrated ambient events
- `hud.js`: Displays lore epithet, epoch, familiar name/stage
- `input_toolbar.js`: Added MIDI and video export buttons
- `effects.js`: Added StarFall cataclysm to Classical blueprint
- `help_overlay.js`: Added keyboard shortcuts for new features
- `index.html`: Added manifest link, service worker registration
- `main.js`: Integrated particle engine initialization

## Notable Implementation Details
- Metro map uses cached segment hints for efficient arc-length train positioning
- Familiar species defined as pluggable modules with init/update/draw lifecycle
- Epoch modifiers recaptured per-universe to avoid conflicts with blueprint setup
- Journal capped at 150 entries with LRU eviction
- All new systems are CSP-safe (no innerHTML, no DOM strings)
- Video export composites both render layers (background + particles) per frame

https://claude.ai/code/session_01UhGizSfq6HU8x3kUDJGPxN